### PR TITLE
never return null for collections in describeRepo

### DIFF
--- a/server/handle_repo_describe_repo.go
+++ b/server/handle_repo_describe_repo.go
@@ -69,7 +69,7 @@ func (s *Server) handleDescribeRepo(e echo.Context) error {
 		return helpers.ServerError(e, nil)
 	}
 
-	var collections []string
+	var collections []string = make([]string, 0)
 	for _, r := range records {
 		collections = append(collections, r.Nsid)
 	}


### PR DESCRIPTION
in a repo with no records, the collections field here ends up being the
nil slice instead of an empty slice, so you get null in the response.

since collections is a required field in the rpc def we shouldn't do this,
it breaks pdsls at least.
