### PR TITLE
if prefs are null in db, don't return {} on getPrefs

### DIFF
--- a/server/handle_actor_get_preferences.go
+++ b/server/handle_actor_get_preferences.go
@@ -14,7 +14,7 @@ func (s *Server) handleActorGetPreferences(e echo.Context) error {
 
 	var prefs map[string]any
 	err := json.Unmarshal(repo.Preferences, &prefs)
-	if err != nil {
+	if err != nil || prefs == nil {
 		prefs = map[string]any{
 			"preferences": map[string]any{},
 		}


### PR DESCRIPTION
currently if you haven't putPreferences at all you break social-app,
since it expects response.preferences to always be present
