### PR TITLE
clear DID cache entry on PDS after identity.updateHandle

### DIFF
--- a/server/handle_identity_update_handle.go
+++ b/server/handle_identity_update_handle.go
@@ -81,6 +81,10 @@ func (s *Server) handleIdentityUpdateHandle(e echo.Context) error {
 		}
 	}
 
+	if err := s.passport.BustDoc(context.TODO(), repo.Repo.Did); err != nil {
+		s.logger.Warn("error busting did doc", "error", err)
+	}
+
 	s.evtman.AddEvent(context.TODO(), &events.XRPCStreamEvent{
 		RepoHandle: &atproto.SyncSubscribeRepos_Handle{
 			Did:    repo.Repo.Did,


### PR DESCRIPTION
this ensures that describeRepo gives us the right did doc after we make an updateHandle call

we emit an #identity guy on the event stream so we might as well bust our own cache as well as everybody else's

ref bluesky-social/atproto#3393
