### PR TITLE
support multiple cids in getblocks

### DIFF
--- a/server/handle_sync_get_blocks.go
+++ b/server/handle_sync_get_blocks.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"bytes"
-	"context"
-	"strings"
 
 	"github.com/bluesky-social/indigo/carstore"
 	"github.com/haileyok/cocoon/internal/helpers"
@@ -14,14 +12,17 @@ import (
 )
 
 func (s *Server) handleGetBlocks(e echo.Context) error {
+	ctx := e.Request().Context()
 	did := e.QueryParam("did")
-	cidsstr := e.QueryParam("cids")
 	if did == "" {
 		return helpers.InputError(e, nil)
 	}
 
-	cidstrs := strings.Split(cidsstr, ",")
-	cids := []cid.Cid{}
+	cidstrs, ok := e.QueryParams()["cids"]
+	if !ok {
+		return helpers.InputError(e, nil)
+	}
+	var cids []cid.Cid
 
 	for _, cs := range cidstrs {
 		c, err := cid.Cast([]byte(cs))
@@ -56,7 +57,7 @@ func (s *Server) handleGetBlocks(e echo.Context) error {
 	bs := s.getBlockstore(urepo.Repo.Did)
 
 	for _, c := range cids {
-		b, err := bs.Get(context.TODO(), c)
+		b, err := bs.Get(ctx, c)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
fixes #16 

use `e.QeuryParams()` instead of `e.QueryParam()` to get multiple cids from the url params