### PR TITLE
request crawl when websocket dies

### DIFF
--- a/server/handle_sync_subscribe_repos.go
+++ b/server/handle_sync_subscribe_repos.go
@@ -1,7 +1,8 @@
 package server
 
 import (
-	"fmt"
+	"context"
+	"time"
 
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/lex/util"
@@ -10,16 +11,18 @@ import (
 )
 
 func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
+	ctx := e.Request().Context()
+	logger := s.logger.With("component", "subscribe-repos-websocket")
+
 	conn, err := websocket.Upgrade(e.Response().Writer, e.Request(), e.Response().Header(), 1<<10, 1<<10)
 	if err != nil {
+		logger.Error("unable to establish websocket with relay", "err", err)
 		return err
 	}
 
-	s.logger.Info("new connection", "ua", e.Request().UserAgent())
-
-	ctx := e.Request().Context()
-
 	ident := e.RealIP() + "-" + e.Request().UserAgent()
+	logger = logger.With("ident", ident)
+	logger.Info("new connection established")
 
 	evts, cancel, err := s.evtman.Subscribe(ctx, ident, func(evt *events.XRPCStreamEvent) bool {
 		return true
@@ -33,11 +36,16 @@ func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
 	for evt := range evts {
 		wc, err := conn.NextWriter(websocket.BinaryMessage)
 		if err != nil {
-			return err
+			logger.Error("error writing message to relay", "err", err)
+			break
+		}
+
+		if ctx.Err() != nil {
+			logger.Error("context error", "err", err)
+			break
 		}
 
 		var obj util.CBOR
-
 		switch {
 		case evt.Error != nil:
 			header.Op = events.EvtKindErrorFrame
@@ -55,20 +63,32 @@ func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
 			header.MsgType = "#info"
 			obj = evt.RepoInfo
 		default:
-			return fmt.Errorf("unrecognized event kind")
+			logger.Warn("unrecognized event kind")
+			return nil
 		}
 
 		if err := header.MarshalCBOR(wc); err != nil {
-			return fmt.Errorf("failed to write header: %w", err)
+			logger.Error("failed to write header to relay", "err", err)
+			break
 		}
 
 		if err := obj.MarshalCBOR(wc); err != nil {
-			return fmt.Errorf("failed to write event: %w", err)
+			logger.Error("failed to write event to relay", "err", err)
+			break
 		}
 
 		if err := wc.Close(); err != nil {
-			return fmt.Errorf("failed to flush-close our event write: %w", err)
+			logger.Error("failed to flush-close our event write", "err", err)
+			break
 		}
+	}
+
+	// we should tell the relay to request a new crawl at this point if we got disconnected
+	// use a new context since the old one might be cancelled at this point
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := s.requestCrawl(ctx); err != nil {
+		logger.Error("error requesting crawls", "err", err)
 	}
 
 	return nil


### PR DESCRIPTION
made logging a bit more verbose for websocket failures, and specifically re-requesting crawl to the configured relays when a connection drops