### PR TITLE
Fix proxying getFeed to issue a token for the feed generator

### DIFF
--- a/server/handle_proxy_get_feed.go
+++ b/server/handle_proxy_get_feed.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/haileyok/cocoon/internal/helpers"
+	"github.com/labstack/echo/v4"
+)
+
+func (s *Server) handleProxyBskyFeedGetFeed(e echo.Context) error {
+	feedUri, err := syntax.ParseATURI(e.QueryParam("feed"))
+	if err != nil {
+		return helpers.InputError(e, to.StringPtr("invalid feed uri"))
+	}
+
+	appViewEndpoint, _, err := s.getAtprotoProxyEndpointFromRequest(e)
+	if err != nil {
+		e.Logger().Error("could not get atproto proxy", "error", err)
+		return helpers.ServerError(e, nil)
+	}
+
+	appViewClient := xrpc.Client{
+		Host: appViewEndpoint,
+	}
+	feedRecord, err := atproto.RepoGetRecord(e.Request().Context(), &appViewClient, "", feedUri.Collection().String(), feedUri.Authority().String(), feedUri.RecordKey().String())
+	feedGeneratorDid := feedRecord.Value.Val.(*bsky.FeedGenerator).Did
+
+	e.Set("proxyTokenLxm", "app.bsky.feed.getFeedSkeleton")
+	e.Set("proxyTokenAud", feedGeneratorDid)
+
+	return s.handleProxy(e)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -484,6 +484,7 @@ func (s *Server) addRoutes() {
 	// stupid silly endpoints
 	s.echo.GET("/xrpc/app.bsky.actor.getPreferences", s.handleActorGetPreferences, s.handleLegacySessionMiddleware, s.handleOauthSessionMiddleware)
 	s.echo.POST("/xrpc/app.bsky.actor.putPreferences", s.handleActorPutPreferences, s.handleLegacySessionMiddleware, s.handleOauthSessionMiddleware)
+	s.echo.GET("/xrpc/app.bsky.feed.getFeed", s.handleProxyBskyFeedGetFeed, s.handleLegacySessionMiddleware, s.handleOauthSessionMiddleware)
 
 	// admin routes
 	s.echo.POST("/xrpc/com.atproto.server.createInviteCode", s.handleCreateInviteCode, s.handleAdminMiddleware)


### PR DESCRIPTION
While most feed generators don't enforce it, feed generators are supposed to check that the service auth token they receive:
* Has the DID of the feed generator in the `aud` claim
* Has `app.bsky.feed.getFeedSkeleton` in the `lxm` claim

Since the app view calls the feed generator and the app view can't issue service auth tokens, the PDS is expected to issue such a token when proxying `app.bsky.feed.getFeed` to the app view which is then passed on to the feed generator.

This PR implements this special case of proxying in so that people can use feed generators that strictly validate the auth token.