### PR TITLE
fix audience for get feed proxy

### DIFF
--- a/server/handle_proxy.go
+++ b/server/handle_proxy.go
@@ -111,7 +111,7 @@ func (s *Server) handleProxy(e echo.Context) error {
 
 		payload := map[string]any{
 			"iss": repo.Repo.Did,
-			"aud": svcDid,
+			"aud": aud,
 			"lxm": lxm,
 			"jti": uuid.NewString(),
 			"exp": time.Now().Add(1 * time.Minute).UTC().Unix(),


### PR DESCRIPTION
https://github.com/haileyok/cocoon/pull/38 was supposed to set both the LXM and AUD claims when proxying feeds.

But it looks like I missed the AUD and the feed I was testing it with was only validating the LXM not the AUD.

This is actually using the correct AUD for proxing this method, the logic for getting it was correct, it just wasn't being used.