### PR TITLE
Multiplatform Docker Images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,14 +14,23 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
-      #
+    outputs:
+      digest-amd64: ${{ matrix.arch == 'amd64' && steps.push.outputs.digest || '' }}
+      digest-arm64: ${{ matrix.arch == 'arm64' && steps.push.outputs.digest || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,11 +50,11 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha
-            type=sha,format=long
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}},suffix=-${{ matrix.arch }}
+            type=sha,suffix=-${{ matrix.arch }}
+            type=sha,format=long,suffix=-${{ matrix.arch }}
+            type=semver,pattern={{version}},suffix=-${{ matrix.arch }}
+            type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.arch }}
 
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
@@ -59,10 +68,49 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  publish-manifest:
+    needs: build-and-push-image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+            type=sha,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Create and push manifest
+        run: |
+          # Split tags into an array
+          readarray -t tags <<< "${{ steps.meta.outputs.tags }}"
+
+          # Create and push manifest for each tag
+          for tag in "${tags[@]}"; do
+            docker buildx imagetools create -t "$tag" \
+              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push-image.outputs.digest-amd64 }}" \
+              "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push-image.outputs.digest-arm64 }}"
+          done
+
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ needs.build-and-push-image.outputs.digest-amd64 }}
           push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always || echo "dev-local") && \
 ### Run stage
 FROM debian:bookworm-slim AS run
 
-RUN apt-get update && apt-get install -y dumb-init runit ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y dumb-init runit ca-certificates curl && rm -rf /var/lib/apt/lists/*
 ENTRYPOINT ["dumb-init", "--"]
 
 WORKDIR /


### PR DESCRIPTION
I was trying to run cocoon on an arm64 device and realised the image tags are only for amd64.

The updated action builds both architectures with suffixes (`-amd64`, `-arm64`) and then creates merged manifests. I've got an example run [here](https://github.com/supleed2/cocoon/actions/runs/20005030743) and the resulting images [here](https://github.com/supleed2/cocoon/pkgs/container/cocoon/versions).

I'm not exactly sure why one of the sha256 tagged images ends up untagged, sorry about that! But overall it seems to work.

Also, I have cocoon running [behind a cloudflare tunnel](https://cocoon.8bitsqu.id/), and it seems to work (but I think importing accounts hasn't been added yet?), though I needed to add `curl` to the image for the healthcheck to work?