### PR TITLE
feat: skip blobs with empty or invalid CIDs

### DIFF
--- a/server/handle_sync_list_blobs.go
+++ b/server/handle_sync_list_blobs.go
@@ -59,10 +59,14 @@ func (s *Server) handleSyncListBlobs(e echo.Context) error {
 
 	var cstrs []string
 	for _, b := range blobs {
+		if len(b.Cid) == 0 {
+			logger.Error("empty cid found", "blob", b)
+			continue
+		}
 		c, err := cid.Cast(b.Cid)
 		if err != nil {
 			logger.Error("error casting cid", "error", err)
-			return helpers.ServerError(e, nil)
+			continue
 		}
 		cstrs = append(cstrs, c.String())
 	}


### PR DESCRIPTION
Instead of returning an error when encountering an empty or invalid CID, log the error and continue processing the remaining blobs.

I don't know why this happened, but it did happen when importing 1.2k blobs from bsky.social via a car file..