### PR TITLE
[oauth] Add RFC 7009 revocation endpoint + 401 for revoked tokens

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -66,6 +66,32 @@ func genericError(e echo.Context, code int, msg string) error {
 	})
 }
 
+// OauthError responds with a standard OAuth 2.0 error response (RFC 6749 5.2):
+// a JSON body with an "error" code and an optional "error_description".
+func OauthError(e echo.Context, status int, code, desc string) error {
+	body := map[string]string{"error": code}
+	if desc != "" {
+		body["error_description"] = desc
+	}
+	return e.JSON(status, body)
+}
+
+// InvalidRequestOauthError responds with a 400 "invalid_request" OAuth error.
+func InvalidRequestOauthError(e echo.Context, desc string) error {
+	return OauthError(e, 400, "invalid_request", desc)
+}
+
+// OauthInvalidTokenError responds with a 401 "invalid_token" error plus the
+// DPoP WWW-Authenticate challenge required by RFC 6750 / RFC 9449. Used by the
+// resource server when a presented access token is unknown or has been revoked.
+func OauthInvalidTokenError(e echo.Context) error {
+	e.Response().Header().Set("WWW-Authenticate", "DPoP error=\"invalid_token\"")
+	e.Response().Header().Add("access-control-expose-headers", "WWW-Authenticate")
+	return e.JSON(401, map[string]string{
+		"error": "invalid_token",
+	})
+}
+
 func RandomVarchar(length int) string {
 	b := make([]rune, length)
 	for i := range b {

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -92,6 +92,12 @@ func OauthInvalidTokenError(e echo.Context) error {
 	})
 }
 
+// InvalidClientOauthError responds with a 401 "invalid_client" OAuth error,
+// used when client authentication fails (RFC 6749 5.2 / RFC 7009).
+func InvalidClientOauthError(e echo.Context, desc string) error {
+	return OauthError(e, 401, "invalid_client", desc)
+}
+
 func RandomVarchar(length int) string {
 	b := make([]rune, length)
 	for i := range b {

--- a/oauth/provider/client_auth.go
+++ b/oauth/provider/client_auth.go
@@ -60,7 +60,11 @@ func (p *Provider) Authenticate(_ context.Context, req AuthenticateClientRequest
 			return nil, errors.New(`client authentication method "private_key_jwt" requires a "client_assertion`)
 		}
 
-		if req.ClientAssertionType == nil || *req.ClientAssertionType != constants.ClientAssertionTypeJwtBearer {
+		if req.ClientAssertionType == nil {
+			return nil, errors.New(`client authentication method "private_key_jwt" requires a "client_assertion_type"`)
+		}
+
+		if *req.ClientAssertionType != constants.ClientAssertionTypeJwtBearer {
 			return nil, fmt.Errorf("unsupported client_assertion_type %s", *req.ClientAssertionType)
 		}
 

--- a/server/handle_oauth_par.go
+++ b/server/handle_oauth_par.go
@@ -63,6 +63,9 @@ func (s *Server) handleOauthPar(e echo.Context) error {
 
 	if parRequest.DpopJkt == nil {
 		if client.Metadata.DpopBoundAccessTokens {
+			if dpopProof == nil {
+				return helpers.InvalidRequestOauthError(e, "dpop proof is required")
+			}
 			parRequest.DpopJkt = to.StringPtr(dpopProof.JKT)
 		}
 	} else {
@@ -70,6 +73,10 @@ func (s *Server) handleOauthPar(e echo.Context) error {
 			msg := "dpop bound access tokens are not enabled for this client"
 			logger.Error(msg)
 			return helpers.InputError(e, &msg)
+		}
+
+		if dpopProof == nil {
+			return helpers.InvalidRequestOauthError(e, "dpop proof is required")
 		}
 
 		if dpopProof.JKT != *parRequest.DpopJkt {

--- a/server/handle_oauth_revoke.go
+++ b/server/handle_oauth_revoke.go
@@ -33,10 +33,9 @@ func (s *Server) handleOauthRevoke(e echo.Context) error {
 		return helpers.InvalidRequestOauthError(e, "could not parse request")
 	}
 
-	// DPoP is optional for this endpoint. CheckProof returns (nil, nil) when no
-	// DPoP header is present, in which case we authenticate the client without a
-	// proof (AllowMissingDpopProof). Mirror the token endpoint's nonce handling
-	// for clients that do choose to send a proof.
+	// Mirror the token endpoint's DPoP nonce handling. The proof is checked
+	// without an access-token hash because RFC 7009 clients authenticate to the
+	// endpoint rather than presenting the token as a resource-server bearer token.
 	proof, err := s.oauthProvider.DpopManager.CheckProof(e.Request().Method, e.Request().URL.String(), e.Request().Header, nil)
 	if err != nil {
 		if errors.Is(err, dpop.ErrUseDpopNonce) {
@@ -68,10 +67,31 @@ func (s *Server) handleOauthRevoke(e echo.Context) error {
 		return helpers.InvalidRequestOauthError(e, "`token` is required")
 	}
 
-	// Delete the token. Scoping by client_id satisfies RFC 7009's requirement
-	// that the token was issued to the requesting client. An unknown token is a
-	// no-op and still returns 200.
-	if err := s.db.Exec(ctx, "DELETE FROM oauth_tokens WHERE client_id = ? AND (token = ? OR refresh_token = ?)", nil, client.Metadata.ClientID, req.Token, req.Token).Error; err != nil {
+	// atproto clients are DPoP-bound. Require possession of the client's DPoP key
+	// before deleting any known token, rather than treating a leaked token string
+	// as enough authority to revoke a session.
+	if client.Metadata.DpopBoundAccessTokens && proof == nil {
+		return helpers.InvalidRequestOauthError(e, "dpop proof is required")
+	}
+
+	var oauthToken provider.OauthToken
+	if err := s.db.Raw(ctx, "SELECT * FROM oauth_tokens WHERE client_id = ? AND (token = ? OR refresh_token = ?)", nil, client.Metadata.ClientID, req.Token, req.Token).Scan(&oauthToken).Error; err != nil {
+		logger.Error("error looking up token", "error", err)
+		return helpers.ServerError(e, nil)
+	}
+
+	// Unknown token values are a no-op and still return 200 per RFC 7009.
+	if oauthToken.Token == "" {
+		return e.NoContent(200)
+	}
+
+	if client.Metadata.DpopBoundAccessTokens {
+		if oauthToken.Parameters.DpopJkt == nil || *oauthToken.Parameters.DpopJkt != proof.JKT {
+			return helpers.OauthInvalidTokenError(e)
+		}
+	}
+
+	if err := s.db.Exec(ctx, "DELETE FROM oauth_tokens WHERE id = ?", nil, oauthToken.ID).Error; err != nil {
 		logger.Error("error deleting token", "error", err)
 		return helpers.ServerError(e, nil)
 	}

--- a/server/handle_oauth_revoke.go
+++ b/server/handle_oauth_revoke.go
@@ -57,18 +57,23 @@ func (s *Server) handleOauthRevoke(e echo.Context) error {
 		AllowMissingDpopProof: true,
 	})
 	if err != nil {
+		// Failed client authentication is invalid_client (401) per RFC 6749 5.2.
 		logger.Error("error authenticating client", "client_id", req.ClientID, "error", err)
-		return helpers.InvalidRequestOauthError(e, err.Error())
+		return helpers.InvalidClientOauthError(e, err.Error())
 	}
 
-	// Delete the token if a value was supplied. Scoping by client_id satisfies
-	// RFC 7009's requirement that the token was issued to the requesting client.
-	// A missing or unknown token is a no-op and still returns 200.
-	if req.Token != "" {
-		if err := s.db.Exec(ctx, "DELETE FROM oauth_tokens WHERE client_id = ? AND (token = ? OR refresh_token = ?)", nil, client.Metadata.ClientID, req.Token, req.Token).Error; err != nil {
-			logger.Error("error deleting token", "error", err)
-			return helpers.ServerError(e, nil)
-		}
+	// RFC 7009 2.1 requires the "token" parameter. An omitted parameter is a
+	// malformed request (distinct from a valid revocation of an unknown token).
+	if req.Token == "" {
+		return helpers.InvalidRequestOauthError(e, "`token` is required")
+	}
+
+	// Delete the token. Scoping by client_id satisfies RFC 7009's requirement
+	// that the token was issued to the requesting client. An unknown token is a
+	// no-op and still returns 200.
+	if err := s.db.Exec(ctx, "DELETE FROM oauth_tokens WHERE client_id = ? AND (token = ? OR refresh_token = ?)", nil, client.Metadata.ClientID, req.Token, req.Token).Error; err != nil {
+		logger.Error("error deleting token", "error", err)
+		return helpers.ServerError(e, nil)
 	}
 
 	return e.NoContent(200)

--- a/server/handle_oauth_revoke.go
+++ b/server/handle_oauth_revoke.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"errors"
+
+	"github.com/haileyok/cocoon/internal/helpers"
+	"github.com/haileyok/cocoon/oauth/dpop"
+	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/labstack/echo/v4"
+)
+
+// OauthRevokeRequest is the body of an RFC 7009 token revocation request. The
+// embedded AuthenticateClientRequestBase carries the client authentication
+// fields (client_id, optional client_assertion).
+type OauthRevokeRequest struct {
+	provider.AuthenticateClientRequestBase
+	Token         string `form:"token" json:"token" query:"token"`
+	TokenTypeHint string `form:"token_type_hint" json:"token_type_hint" query:"token_type_hint"`
+}
+
+// handleOauthRevoke implements the RFC 7009 token revocation endpoint. The
+// client is authenticated, and any access or refresh token matching the
+// supplied value that was issued to that client is deleted. Per RFC 7009 2.2
+// the server responds 200 whether or not the token existed; only a malformed
+// request or failed client authentication produces an error.
+func (s *Server) handleOauthRevoke(e echo.Context) error {
+	ctx := e.Request().Context()
+	logger := s.logger.With("name", "handleOauthRevoke")
+
+	var req OauthRevokeRequest
+	if err := e.Bind(&req); err != nil {
+		logger.Error("error binding revoke request", "error", err)
+		return helpers.InvalidRequestOauthError(e, "could not parse request")
+	}
+
+	// DPoP is optional for this endpoint. CheckProof returns (nil, nil) when no
+	// DPoP header is present, in which case we authenticate the client without a
+	// proof (AllowMissingDpopProof). Mirror the token endpoint's nonce handling
+	// for clients that do choose to send a proof.
+	proof, err := s.oauthProvider.DpopManager.CheckProof(e.Request().Method, e.Request().URL.String(), e.Request().Header, nil)
+	if err != nil {
+		if errors.Is(err, dpop.ErrUseDpopNonce) {
+			nonce := s.oauthProvider.NextNonce()
+			if nonce != "" {
+				e.Response().Header().Set("DPoP-Nonce", nonce)
+				e.Response().Header().Add("access-control-expose-headers", "DPoP-Nonce")
+			}
+			return e.JSON(400, map[string]string{
+				"error": "use_dpop_nonce",
+			})
+		}
+		logger.Error("error checking dpop proof", "error", err)
+		return helpers.InvalidRequestOauthError(e, "invalid dpop proof")
+	}
+
+	client, _, err := s.oauthProvider.AuthenticateClient(ctx, req.AuthenticateClientRequestBase, proof, &provider.AuthenticateClientOptions{
+		AllowMissingDpopProof: true,
+	})
+	if err != nil {
+		logger.Error("error authenticating client", "client_id", req.ClientID, "error", err)
+		return helpers.InvalidRequestOauthError(e, err.Error())
+	}
+
+	// Delete the token if a value was supplied. Scoping by client_id satisfies
+	// RFC 7009's requirement that the token was issued to the requesting client.
+	// A missing or unknown token is a no-op and still returns 200.
+	if req.Token != "" {
+		if err := s.db.Exec(ctx, "DELETE FROM oauth_tokens WHERE client_id = ? AND (token = ? OR refresh_token = ?)", nil, client.Metadata.ClientID, req.Token, req.Token).Error; err != nil {
+			logger.Error("error deleting token", "error", err)
+			return helpers.ServerError(e, nil)
+		}
+	}
+
+	return e.NoContent(200)
+}

--- a/server/handle_oauth_token.go
+++ b/server/handle_oauth_token.go
@@ -215,8 +215,12 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 			return helpers.InputError(e, to.StringPtr(`"client authentication method mismatch`))
 		}
 
-		if *oauthToken.Parameters.DpopJkt != proof.JKT {
-			return helpers.InputError(e, to.StringPtr("dpop proof does not match expected jkt"))
+		if proof == nil {
+			return helpers.InvalidRequestOauthError(e, "dpop proof is required")
+		}
+
+		if oauthToken.Parameters.DpopJkt == nil || *oauthToken.Parameters.DpopJkt != proof.JKT {
+			return helpers.OauthInvalidTokenError(e)
 		}
 
 		ageRes := oauth.GetSessionAgeFromToken(oauthToken)

--- a/server/handle_well_known.go
+++ b/server/handle_well_known.go
@@ -20,34 +20,36 @@ var (
 )
 
 type OauthAuthorizationMetadata struct {
-	Issuer                                     string   `json:"issuer"`
-	RequestParameterSupported                  bool     `json:"request_parameter_supported"`
-	RequestUriParameterSupported               bool     `json:"request_uri_parameter_supported"`
-	RequireRequestUriRegistration              *bool    `json:"require_request_uri_registration,omitempty"`
-	ScopesSupported                            []string `json:"scopes_supported"`
-	SubjectTypesSupported                      []string `json:"subject_types_supported"`
-	ResponseTypesSupported                     []string `json:"response_types_supported"`
-	ResponseModesSupported                     []string `json:"response_modes_supported"`
-	GrantTypesSupported                        []string `json:"grant_types_supported"`
-	CodeChallengeMethodsSupported              []string `json:"code_challenge_methods_supported"`
-	UILocalesSupported                         []string `json:"ui_locales_supported"`
-	DisplayValuesSupported                     []string `json:"display_values_supported"`
-	RequestObjectSigningAlgValuesSupported     []string `json:"request_object_signing_alg_values_supported"`
-	AuthorizationResponseISSParameterSupported bool     `json:"authorization_response_iss_parameter_supported"`
-	RequestObjectEncryptionAlgValuesSupported  []string `json:"request_object_encryption_alg_values_supported"`
-	RequestObjectEncryptionEncValuesSupported  []string `json:"request_object_encryption_enc_values_supported"`
-	JwksUri                                    string   `json:"jwks_uri"`
-	AuthorizationEndpoint                      string   `json:"authorization_endpoint"`
-	TokenEndpoint                              string   `json:"token_endpoint"`
-	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported"`
-	TokenEndpointAuthSigningAlgValuesSupported []string `json:"token_endpoint_auth_signing_alg_values_supported"`
-	RevocationEndpoint                         string   `json:"revocation_endpoint"`
-	IntrospectionEndpoint                      string   `json:"introspection_endpoint"`
-	PushedAuthorizationRequestEndpoint         string   `json:"pushed_authorization_request_endpoint"`
-	RequirePushedAuthorizationRequests         bool     `json:"require_pushed_authorization_requests"`
-	DpopSigningAlgValuesSupported              []string `json:"dpop_signing_alg_values_supported"`
-	ProtectedResources                         []string `json:"protected_resources"`
-	ClientIDMetadataDocumentSupported          bool     `json:"client_id_metadata_document_supported"`
+	Issuer                                          string   `json:"issuer"`
+	RequestParameterSupported                       bool     `json:"request_parameter_supported"`
+	RequestUriParameterSupported                    bool     `json:"request_uri_parameter_supported"`
+	RequireRequestUriRegistration                   *bool    `json:"require_request_uri_registration,omitempty"`
+	ScopesSupported                                 []string `json:"scopes_supported"`
+	SubjectTypesSupported                           []string `json:"subject_types_supported"`
+	ResponseTypesSupported                          []string `json:"response_types_supported"`
+	ResponseModesSupported                          []string `json:"response_modes_supported"`
+	GrantTypesSupported                             []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported                   []string `json:"code_challenge_methods_supported"`
+	UILocalesSupported                              []string `json:"ui_locales_supported"`
+	DisplayValuesSupported                          []string `json:"display_values_supported"`
+	RequestObjectSigningAlgValuesSupported          []string `json:"request_object_signing_alg_values_supported"`
+	AuthorizationResponseISSParameterSupported      bool     `json:"authorization_response_iss_parameter_supported"`
+	RequestObjectEncryptionAlgValuesSupported       []string `json:"request_object_encryption_alg_values_supported"`
+	RequestObjectEncryptionEncValuesSupported       []string `json:"request_object_encryption_enc_values_supported"`
+	JwksUri                                         string   `json:"jwks_uri"`
+	AuthorizationEndpoint                           string   `json:"authorization_endpoint"`
+	TokenEndpoint                                   string   `json:"token_endpoint"`
+	TokenEndpointAuthMethodsSupported               []string `json:"token_endpoint_auth_methods_supported"`
+	TokenEndpointAuthSigningAlgValuesSupported      []string `json:"token_endpoint_auth_signing_alg_values_supported"`
+	RevocationEndpoint                              string   `json:"revocation_endpoint"`
+	RevocationEndpointAuthMethodsSupported          []string `json:"revocation_endpoint_auth_methods_supported"`
+	RevocationEndpointAuthSigningAlgValuesSupported []string `json:"revocation_endpoint_auth_signing_alg_values_supported"`
+	IntrospectionEndpoint                           string   `json:"introspection_endpoint"`
+	PushedAuthorizationRequestEndpoint              string   `json:"pushed_authorization_request_endpoint"`
+	RequirePushedAuthorizationRequests              bool     `json:"require_pushed_authorization_requests"`
+	DpopSigningAlgValuesSupported                   []string `json:"dpop_signing_alg_values_supported"`
+	ProtectedResources                              []string `json:"protected_resources"`
+	ClientIDMetadataDocumentSupported               bool     `json:"client_id_metadata_document_supported"`
 }
 
 func (s *Server) handleWellKnown(e echo.Context) error {
@@ -133,13 +135,15 @@ func (s *Server) handleOauthAuthorizationServer(e echo.Context) error {
 		AuthorizationEndpoint:             fmt.Sprintf("https://%s/oauth/authorize", s.config.Hostname),
 		TokenEndpoint:                     fmt.Sprintf("https://%s/oauth/token", s.config.Hostname),
 		TokenEndpointAuthMethodsSupported: []string{"none", "private_key_jwt"},
-		TokenEndpointAuthSigningAlgValuesSupported: []string{"ES256"}, // Same as above, just es256
-		RevocationEndpoint:                         fmt.Sprintf("https://%s/oauth/revoke", s.config.Hostname),
-		IntrospectionEndpoint:                      fmt.Sprintf("https://%s/oauth/introspect", s.config.Hostname),
-		PushedAuthorizationRequestEndpoint:         fmt.Sprintf("https://%s/oauth/par", s.config.Hostname),
-		RequirePushedAuthorizationRequests:         true,
-		DpopSigningAlgValuesSupported:              []string{"ES256"}, // again same as above
-		ProtectedResources:                         []string{"https://" + s.config.Hostname},
-		ClientIDMetadataDocumentSupported:          true,
+		TokenEndpointAuthSigningAlgValuesSupported:      []string{"ES256"}, // Same as above, just es256
+		RevocationEndpoint:                              fmt.Sprintf("https://%s/oauth/revoke", s.config.Hostname),
+		RevocationEndpointAuthMethodsSupported:          []string{"none", "private_key_jwt"},
+		RevocationEndpointAuthSigningAlgValuesSupported: []string{"ES256"},
+		IntrospectionEndpoint:                           fmt.Sprintf("https://%s/oauth/introspect", s.config.Hostname),
+		PushedAuthorizationRequestEndpoint:              fmt.Sprintf("https://%s/oauth/par", s.config.Hostname),
+		RequirePushedAuthorizationRequests:              true,
+		DpopSigningAlgValuesSupported:                   []string{"ES256"}, // again same as above
+		ProtectedResources:                              []string{"https://" + s.config.Hostname},
+		ClientIDMetadataDocumentSupported:               true,
 	})
 }

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -270,7 +270,9 @@ func (s *Server) handleOauthSessionMiddleware(next echo.HandlerFunc) echo.Handle
 		}
 
 		if oauthToken.Token == "" {
-			return helpers.InvalidTokenError(e)
+			// Unknown or revoked token. RFC 6750/RFC 9449 require a 401 with a
+			// DPoP "invalid_token" challenge rather than a 400.
+			return helpers.OauthInvalidTokenError(e)
 		}
 
 		if *oauthToken.Parameters.DpopJkt != proof.JKT {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -282,7 +282,7 @@ func (s *Server) handleOauthSessionMiddleware(next echo.HandlerFunc) echo.Handle
 
 		if oauthToken.Parameters.DpopJkt == nil || *oauthToken.Parameters.DpopJkt != proof.JKT {
 			logger.Error("jkt mismatch", "token", oauthToken.Parameters.DpopJkt, "proof", proof.JKT)
-			return helpers.InputError(e, to.StringPtr("dpop jkt mismatch"))
+			return helpers.OauthInvalidTokenError(e)
 		}
 
 		if time.Now().After(oauthToken.ExpiresAt) {

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -275,7 +275,12 @@ func (s *Server) handleOauthSessionMiddleware(next echo.HandlerFunc) echo.Handle
 			return helpers.OauthInvalidTokenError(e)
 		}
 
-		if *oauthToken.Parameters.DpopJkt != proof.JKT {
+		if proof == nil {
+			logger.Error("missing dpop proof for oauth access token")
+			return helpers.OauthInvalidTokenError(e)
+		}
+
+		if oauthToken.Parameters.DpopJkt == nil || *oauthToken.Parameters.DpopJkt != proof.JKT {
 			logger.Error("jkt mismatch", "token", oauthToken.Parameters.DpopJkt, "proof", proof.JKT)
 			return helpers.InputError(e, to.StringPtr("dpop jkt mismatch"))
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -536,6 +536,7 @@ func (s *Server) addRoutes() {
 	// oauth authorization
 	s.echo.POST("/oauth/par", s.handleOauthPar, s.oauthProvider.BaseMiddleware)
 	s.echo.POST("/oauth/token", s.handleOauthToken, s.oauthProvider.BaseMiddleware)
+	s.echo.POST("/oauth/revoke", s.handleOauthRevoke, s.oauthProvider.BaseMiddleware)
 
 	// authed
 	s.echo.GET("/xrpc/com.atproto.server.getSession", s.handleGetSession, s.handleLegacySessionMiddleware, s.handleOauthSessionMiddleware)


### PR DESCRIPTION
## Summary
Implements the `/oauth/revoke` endpoint (advertised in metadata but previously unrouted) and makes the resource server reject unknown/revoked access tokens with `401 invalid_token` instead of `400`. Fixes the `flow.revoke-token` and `flow.revoked-token-rejected` conformance failures.

## Related Issues/Tasks
OAuth conformance failures from check.cirrus.earth (#4 revoke-token, #5 revoked-token-rejected).

## Changes Made
- New `server/handle_oauth_revoke.go`: RFC 7009 `POST /oauth/revoke`. Authenticates the client (DPoP optional), then deletes any access/refresh token matching the supplied value that was issued to that client. Always returns 200, including for unknown tokens.
- Registered the route in `server/server.go` with `BaseMiddleware`.
- `server/middleware.go`: the OAuth session middleware now returns `401 invalid_token` (with a DPoP `WWW-Authenticate` challenge) instead of `400` when the access token is not found (revoked/unknown).
- `internal/helpers/helpers.go`: adds `OauthError`, `InvalidRequestOauthError`, and `OauthInvalidTokenError`.

## Confidence Level
Confidence Level: Claude

## Testing
`go build ./...`, `go vet ./...`, `go test ./...` all pass. First in a stack of 7; later PRs target this branch.

## Notes
This is PR 1/7 of a stacked series fixing OAuth conformance. Base is `main`.