### PR TITLE
[oauth] Reject PAR/authorize with unregistered redirect_uri

### DIFF
--- a/server/handle_oauth_authorize.go
+++ b/server/handle_oauth_authorize.go
@@ -70,6 +70,13 @@ func (s *Server) handleOauthAuthorizeGet(e echo.Context) error {
 			return helpers.ServerError(e, to.StringPtr(err.Error()))
 		}
 
+		// The redirect_uri must exactly match one registered in the client
+		// metadata; an unregistered value would enable an open redirect.
+		if !slices.Contains(client.Metadata.RedirectURIs, parRequest.RedirectURI) {
+			s.logger.Error("redirect_uri not registered for client", "client_id", parRequest.ClientID, "redirect_uri", parRequest.RedirectURI)
+			return helpers.InvalidRequestOauthError(e, "redirect_uri is not registered for this client")
+		}
+
 		if parRequest.DpopJkt == nil {
 			if client.Metadata.DpopBoundAccessTokens {
 			}

--- a/server/handle_oauth_par.go
+++ b/server/handle_oauth_par.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -59,6 +60,13 @@ func (s *Server) handleOauthPar(e echo.Context) error {
 	if err != nil {
 		logger.Error("error authenticating client", "client_id", parRequest.ClientID, "error", err)
 		return helpers.InputError(e, to.StringPtr(err.Error()))
+	}
+
+	// The redirect_uri must exactly match one registered in the client metadata.
+	// Accepting an unregistered value would enable an open-redirect / token theft.
+	if !slices.Contains(client.Metadata.RedirectURIs, parRequest.RedirectURI) {
+		logger.Error("redirect_uri not registered for client", "client_id", parRequest.ClientID, "redirect_uri", parRequest.RedirectURI)
+		return helpers.InvalidRequestOauthError(e, "redirect_uri is not registered for this client")
 	}
 
 	if parRequest.DpopJkt == nil {


### PR DESCRIPTION
## Summary
The PAR handler and the standard (non-PAR) authorize branch never validated the requested `redirect_uri` against the client's registered `redirect_uris`, allowing an open redirect. Both now require an exact match. Fixes the `flow.par-rejects-unregistered-redirect-uri` conformance failure.

## Related Issues/Tasks
OAuth conformance failure (#1 par-rejects-unregistered-redirect-uri).

## Changes Made
- `server/handle_oauth_par.go`: after client authentication, reject a `redirect_uri` not present in `client.Metadata.RedirectURIs` with `400 invalid_request`.
- `server/handle_oauth_authorize.go`: same check in the standard authorize branch.

## Confidence Level
Confidence Level: Claude

## Testing
`go build ./...` and `go vet ./...` pass.

## Notes
PR 2/7 in a stacked series. Base is `pr1-oauth-revoke` (uses the `InvalidRequestOauthError` helper added there); retarget to `main` once PR1 merges.