### PR TITLE
[scopes] Add atproto OAuth scope parser package

### DIFF
--- a/oauth/scopes/scopes.go
+++ b/oauth/scopes/scopes.go
@@ -1,0 +1,164 @@
+// Package scopes parses and evaluates atproto OAuth permission scopes.
+//
+// Scope tokens follow the grammar described at https://atproto.com/specs/permission:
+//
+//	resource[:positional][?params]
+//
+// Examples:
+//
+//	atproto
+//	transition:generic
+//	repo:app.bsky.feed.post
+//	repo:app.bsky.feed.post?action=create
+//	repo:*
+//	blob:image/png
+//	blob?accept=image/*
+//	include:site.standard.authFull?aud=did:web:example.com
+package scopes
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+// Permission is a single parsed scope token.
+type Permission struct {
+	// Resource is the scope resource type, e.g. "atproto", "repo", "blob",
+	// "rpc", "include", "transition".
+	Resource string
+	// Positional is the (percent-decoded) positional parameter that follows the
+	// first ":" in the token, e.g. the collection for "repo:<collection>" or the
+	// NSID for "include:<nsid>". Empty when the token has no positional segment.
+	Positional string
+	// Params holds the query-style parameters that follow "?" in the token.
+	Params url.Values
+}
+
+// ParseToken parses a single scope token of the form
+// resource[:positional][?params].
+func ParseToken(tok string) (Permission, error) {
+	if tok == "" {
+		return Permission{}, fmt.Errorf("empty scope token")
+	}
+
+	p := Permission{Params: url.Values{}}
+
+	// Split the query parameters off on the first "?".
+	left := tok
+	if idx := strings.IndexByte(tok, '?'); idx >= 0 {
+		left = tok[:idx]
+		vals, err := url.ParseQuery(tok[idx+1:])
+		if err != nil {
+			return Permission{}, fmt.Errorf("invalid params in scope %q: %w", tok, err)
+		}
+		p.Params = vals
+	}
+
+	// Split the resource from the positional on the first ":".
+	if idx := strings.IndexByte(left, ':'); idx >= 0 {
+		p.Resource = left[:idx]
+		pos := left[idx+1:]
+		if decoded, err := url.PathUnescape(pos); err == nil {
+			pos = decoded
+		}
+		p.Positional = pos
+	} else {
+		p.Resource = left
+	}
+
+	if p.Resource == "" {
+		return Permission{}, fmt.Errorf("scope %q is missing a resource", tok)
+	}
+
+	return p, nil
+}
+
+// Parse parses a space-separated scope string into individual permissions.
+func Parse(scope string) ([]Permission, error) {
+	fields := strings.Fields(scope)
+	perms := make([]Permission, 0, len(fields))
+	for _, f := range fields {
+		p, err := ParseToken(f)
+		if err != nil {
+			return nil, err
+		}
+		perms = append(perms, p)
+	}
+	return perms, nil
+}
+
+// Has reports whether perms contains a bare resource token (no positional, no
+// params), such as "atproto".
+func Has(perms []Permission, resource string) bool {
+	for _, p := range perms {
+		if p.Resource == resource && p.Positional == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// GrantsAllRepoWrites reports whether perms grant unrestricted repo write
+// access. The legacy "transition:generic" scope is app-password-equivalent and
+// grants full read/write to the repo, so it bypasses granular repo checks.
+func GrantsAllRepoWrites(perms []Permission) bool {
+	for _, p := range perms {
+		if p.Resource == "transition" && p.Positional == "generic" {
+			return true
+		}
+	}
+	return false
+}
+
+// repoActions returns the set of actions a repo permission allows. An empty
+// result means the permission specified no action filter and therefore allows
+// every action (create, update, delete). The "action" parameter may be encoded
+// either as repeated params (action=create&action=update) or as a
+// comma-separated list (action=create,update); both forms are accepted.
+func repoActions(p Permission) []string {
+	var actions []string
+	for _, v := range p.Params["action"] {
+		for _, a := range strings.Split(v, ",") {
+			a = strings.TrimSpace(a)
+			if a != "" {
+				actions = append(actions, a)
+			}
+		}
+	}
+	return actions
+}
+
+// RepoWriteAllowed reports whether perms permit the given action on the given
+// collection. action must be one of "create", "update", "delete". A repo
+// permission matches when its positional is "*" or equals collection, and
+// either it specifies no action filter or its action set contains action.
+func RepoWriteAllowed(perms []Permission, collection, action string) bool {
+	for _, p := range perms {
+		if p.Resource != "repo" {
+			continue
+		}
+		if p.Positional != "*" && p.Positional != collection {
+			continue
+		}
+		actions := repoActions(p)
+		if len(actions) == 0 || slices.Contains(actions, action) {
+			return true
+		}
+	}
+	return false
+}
+
+// BlobAllowed reports whether perms permit uploading a blob. Per the scope
+// grammar a "blob" permission may constrain the accepted MIME types; MIME
+// filtering is intentionally not enforced here, so the mere presence of any
+// blob permission is sufficient.
+func BlobAllowed(perms []Permission) bool {
+	for _, p := range perms {
+		if p.Resource == "blob" {
+			return true
+		}
+	}
+	return false
+}

--- a/oauth/scopes/scopes_test.go
+++ b/oauth/scopes/scopes_test.go
@@ -1,0 +1,171 @@
+package scopes
+
+import "testing"
+
+func TestParseToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		token      string
+		resource   string
+		positional string
+		params     map[string][]string
+		wantErr    bool
+	}{
+		{name: "bare atproto", token: "atproto", resource: "atproto"},
+		{name: "transition generic", token: "transition:generic", resource: "transition", positional: "generic"},
+		{name: "transition email", token: "transition:email", resource: "transition", positional: "email"},
+		{name: "repo collection", token: "repo:app.bsky.feed.post", resource: "repo", positional: "app.bsky.feed.post"},
+		{
+			name:       "repo collection with action",
+			token:      "repo:app.bsky.feed.post?action=create",
+			resource:   "repo",
+			positional: "app.bsky.feed.post",
+			params:     map[string][]string{"action": {"create"}},
+		},
+		{name: "repo wildcard", token: "repo:*", resource: "repo", positional: "*"},
+		{
+			name:       "repo wildcard with action",
+			token:      "repo:*?action=delete",
+			resource:   "repo",
+			positional: "*",
+			params:     map[string][]string{"action": {"delete"}},
+		},
+		{
+			name:       "include with aud",
+			token:      "include:site.standard.authFull?aud=did:web:example.com",
+			resource:   "include",
+			positional: "site.standard.authFull",
+			params:     map[string][]string{"aud": {"did:web:example.com"}},
+		},
+		{name: "blob positional", token: "blob:image/png", resource: "blob", positional: "image/png"},
+		{
+			name:     "blob accept param",
+			token:    "blob?accept=image/*",
+			resource: "blob",
+			params:   map[string][]string{"accept": {"image/*"}},
+		},
+		{name: "empty token", token: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := ParseToken(tt.token)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got none", tt.token)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if p.Resource != tt.resource {
+				t.Errorf("resource: got %q, want %q", p.Resource, tt.resource)
+			}
+			if p.Positional != tt.positional {
+				t.Errorf("positional: got %q, want %q", p.Positional, tt.positional)
+			}
+			for k, want := range tt.params {
+				got := p.Params[k]
+				if len(got) != len(want) {
+					t.Errorf("param %q: got %v, want %v", k, got, want)
+					continue
+				}
+				for i := range want {
+					if got[i] != want[i] {
+						t.Errorf("param %q[%d]: got %q, want %q", k, i, got[i], want[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestParse(t *testing.T) {
+	perms, err := Parse("  atproto   transition:generic repo:app.bsky.feed.post?action=create  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(perms) != 3 {
+		t.Fatalf("expected 3 perms, got %d: %+v", len(perms), perms)
+	}
+	if !Has(perms, "atproto") {
+		t.Errorf("expected atproto present")
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	perms, err := Parse("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(perms) != 0 {
+		t.Errorf("expected 0 perms, got %d", len(perms))
+	}
+}
+
+func TestGrantsAllRepoWrites(t *testing.T) {
+	yes, _ := Parse("atproto transition:generic")
+	if !GrantsAllRepoWrites(yes) {
+		t.Errorf("transition:generic should grant all repo writes")
+	}
+	no, _ := Parse("atproto transition:email repo:app.bsky.feed.post")
+	if GrantsAllRepoWrites(no) {
+		t.Errorf("transition:email + repo should not grant all repo writes")
+	}
+}
+
+func TestRepoWriteAllowed(t *testing.T) {
+	tests := []struct {
+		name       string
+		scope      string
+		collection string
+		action     string
+		want       bool
+	}{
+		{"exact collection any action", "repo:app.bsky.feed.post", "app.bsky.feed.post", "create", true},
+		{"exact collection any action update", "repo:app.bsky.feed.post", "app.bsky.feed.post", "update", true},
+		{"exact collection action match", "repo:app.bsky.feed.post?action=create", "app.bsky.feed.post", "create", true},
+		{"exact collection action mismatch", "repo:app.bsky.feed.post?action=create", "app.bsky.feed.post", "delete", false},
+		{"different collection", "repo:app.bsky.feed.post", "app.bsky.feed.like", "create", false},
+		{"wildcard any collection", "repo:*", "com.example.thing", "delete", true},
+		{"wildcard with action match", "repo:*?action=delete", "com.example.thing", "delete", true},
+		{"wildcard with action mismatch", "repo:*?action=delete", "com.example.thing", "create", false},
+		{"no repo scope", "atproto", "app.bsky.feed.post", "create", false},
+		{"repeated action params", "repo:app.bsky.feed.post?action=create&action=update", "app.bsky.feed.post", "update", true},
+		{"comma separated actions", "repo:app.bsky.feed.post?action=create,delete", "app.bsky.feed.post", "delete", true},
+		{"comma separated actions mismatch", "repo:app.bsky.feed.post?action=create,delete", "app.bsky.feed.post", "update", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			perms, err := Parse(tt.scope)
+			if err != nil {
+				t.Fatalf("parse error: %v", err)
+			}
+			if got := RepoWriteAllowed(perms, tt.collection, tt.action); got != tt.want {
+				t.Errorf("RepoWriteAllowed(%q, %q, %q) = %v, want %v", tt.scope, tt.collection, tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBlobAllowed(t *testing.T) {
+	if !BlobAllowed(mustParse(t, "atproto blob:image/png")) {
+		t.Errorf("blob:image/png should allow blobs")
+	}
+	if !BlobAllowed(mustParse(t, "atproto blob?accept=image/*")) {
+		t.Errorf("blob?accept=image/* should allow blobs")
+	}
+	if BlobAllowed(mustParse(t, "atproto repo:*")) {
+		t.Errorf("repo:* alone should not allow blobs")
+	}
+}
+
+func mustParse(t *testing.T, scope string) []Permission {
+	t.Helper()
+	perms, err := Parse(scope)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	return perms
+}


### PR DESCRIPTION
## Summary
Adds a pure, fully unit-tested `oauth/scopes` package that parses atproto permission scope tokens (`resource[:positional][?params]`) and provides enforcement predicates. No server wiring, so this is risk-free to merge and is the foundation for include resolution and granular write enforcement.

## Related Issues/Tasks
Foundation for OAuth conformance fixes #2 and #3.

## Changes Made
- `oauth/scopes/scopes.go`: `Permission`, `ParseToken`, `Parse`, `Has`, `GrantsAllRepoWrites` (transition:generic), `RepoWriteAllowed` (repo:<collection> with optional `action` filter, `repo:*` wildcard; accepts both repeated and comma-separated action params), `BlobAllowed`.
- `oauth/scopes/scopes_test.go`: covers atproto, transition:*, repo collection/action/wildcard, include, and blob forms.

## Confidence Level
Confidence Level: Claude

## Testing
`go test ./oauth/scopes/...` passes; `go build ./...`, `go vet ./...` pass.

## Notes
PR 3/7 in a stacked series. Base is `pr2-redirect-uri`.