### PR TITLE
[scopes] Resolve include: permission sets via Lexicon resolution

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -32,6 +32,29 @@ func ResolveHandleFromTXT(ctx context.Context, handle string) (string, error) {
 	return "", fmt.Errorf("handle could not be resolved via txt: no record found")
 }
 
+// ResolveLexiconAuthority resolves a Lexicon authority domain (the DNS-ordered
+// authority of an NSID, e.g. "bsky.app" for "app.bsky.feed.post") to the DID
+// that controls it, via the `_lexicon.<authority>` DNS TXT record carrying a
+// `did=` value. See https://atproto.com/specs/lexicon.
+func ResolveLexiconAuthority(ctx context.Context, authority string) (string, error) {
+	name := fmt.Sprintf("_lexicon.%s", authority)
+	recs, err := net.LookupTXT(name)
+	if err != nil {
+		return "", fmt.Errorf("lexicon authority could not be resolved via txt: %w", err)
+	}
+
+	for _, rec := range recs {
+		if strings.HasPrefix(rec, "did=") {
+			maybeDid := strings.TrimPrefix(rec, "did=")
+			if _, err := syntax.ParseDID(maybeDid); err == nil {
+				return maybeDid, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("lexicon authority %q could not be resolved via txt: no did record found", authority)
+}
+
 func ResolveHandleFromWellKnown(ctx context.Context, cli *http.Client, handle string) (string, error) {
 	ustr := fmt.Sprintf("https://%s/.well-known/atproto-did", handle)
 	req, err := http.NewRequestWithContext(

--- a/oauth/scopes/permission_set.go
+++ b/oauth/scopes/permission_set.go
@@ -1,0 +1,237 @@
+package scopes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	cache "github.com/go-pkgz/expirable-cache/v3"
+	"github.com/haileyok/cocoon/identity"
+)
+
+const (
+	// lexiconSchemaCollection is the repo collection under which Lexicon schema
+	// (and permission-set) records are published.
+	lexiconSchemaCollection = "com.atproto.lexicon.schema"
+
+	resolvePositiveTTL = 10 * time.Minute
+	resolveNegativeTTL = 30 * time.Second
+)
+
+// Resolver resolves `include:<nsid>` scope references into the concrete
+// permissions defined by the referenced permission-set Lexicon record. Results
+// (and short-lived negatives) are cached so that scope validation and write
+// enforcement do not hammer the network.
+type Resolver struct {
+	cli   *http.Client
+	cache cache.Cache[string, cacheEntry]
+}
+
+type cacheEntry struct {
+	perms  []Permission
+	errMsg string
+}
+
+// NewResolver constructs a Resolver. The provided HTTP client is reused for DID
+// document and record fetches; if nil, http.DefaultClient is used.
+func NewResolver(cli *http.Client) *Resolver {
+	if cli == nil {
+		cli = http.DefaultClient
+	}
+	return &Resolver{
+		cli:   cli,
+		cache: cache.NewCache[string, cacheEntry]().WithLRU().WithMaxKeys(500).WithTTL(resolvePositiveTTL),
+	}
+}
+
+// ValidateInclude reports whether nsid refers to a resolvable permission set.
+// A nil return means the include is valid; a non-nil error should be surfaced
+// to the client as invalid_scope.
+func (r *Resolver) ValidateInclude(ctx context.Context, nsid string, params url.Values) error {
+	_, err := r.Resolve(ctx, nsid, params)
+	return err
+}
+
+// Resolve returns the permissions granted by the permission set referenced by
+// nsid, applying include params (such as aud) where the set requests it.
+func (r *Resolver) Resolve(ctx context.Context, nsid string, params url.Values) ([]Permission, error) {
+	key := nsid + "\x00" + params.Get("aud")
+	if entry, ok := r.cache.Get(key); ok {
+		if entry.errMsg != "" {
+			return nil, errors.New(entry.errMsg)
+		}
+		return entry.perms, nil
+	}
+
+	perms, err := r.resolve(ctx, nsid, params)
+
+	entry := cacheEntry{perms: perms}
+	ttl := resolvePositiveTTL
+	if err != nil {
+		entry.errMsg = err.Error()
+		ttl = resolveNegativeTTL
+	}
+	r.cache.Set(key, entry, ttl)
+
+	return perms, err
+}
+
+func (r *Resolver) resolve(ctx context.Context, nsid string, params url.Values) ([]Permission, error) {
+	n, err := syntax.ParseNSID(nsid)
+	if err != nil {
+		return nil, fmt.Errorf("invalid include nsid %q: %w", nsid, err)
+	}
+
+	authority := n.Authority()
+	if authority == "" {
+		return nil, fmt.Errorf("could not determine authority for nsid %q", nsid)
+	}
+
+	did, err := identity.ResolveLexiconAuthority(ctx, authority)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve lexicon authority for %q: %w", nsid, err)
+	}
+
+	pds, err := identity.ResolveService(ctx, r.cli, did)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve pds for %s: %w", did, err)
+	}
+
+	rec, err := r.fetchRecord(ctx, pds, did, n.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return permissionsFromRecord(rec, params)
+}
+
+func (r *Resolver) fetchRecord(ctx context.Context, pds, did, nsid string) (*getRecordResponse, error) {
+	u := fmt.Sprintf("%s/xrpc/com.atproto.repo.getRecord?repo=%s&collection=%s&rkey=%s",
+		strings.TrimRight(pds, "/"),
+		url.QueryEscape(did),
+		url.QueryEscape(lexiconSchemaCollection),
+		url.QueryEscape(nsid),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not build getRecord request: %w", err)
+	}
+
+	resp, err := r.cli.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch permission-set record: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("getRecord for lexicon %q returned status %d", nsid, resp.StatusCode)
+	}
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("could not read getRecord response: %w", err)
+	}
+
+	return parseRecordJSON(b)
+}
+
+// getRecordResponse is the relevant subset of a com.atproto.repo.getRecord
+// response for a Lexicon schema record.
+type getRecordResponse struct {
+	Value lexiconDoc `json:"value"`
+}
+
+type lexiconDoc struct {
+	Defs struct {
+		Main permissionSetDef `json:"main"`
+	} `json:"defs"`
+}
+
+type permissionSetDef struct {
+	Type        string              `json:"type"`
+	Permissions []permissionSetItem `json:"permissions"`
+}
+
+type permissionSetItem struct {
+	Type       string   `json:"type"`
+	Resource   string   `json:"resource"`
+	Collection []string `json:"collection"`
+	Action     []string `json:"action"`
+	Accept     []string `json:"accept"`
+	Lxm        []string `json:"lxm"`
+	Aud        string   `json:"aud"`
+	InheritAud bool     `json:"inheritAud"`
+}
+
+func parseRecordJSON(b []byte) (*getRecordResponse, error) {
+	var rec getRecordResponse
+	if err := json.Unmarshal(b, &rec); err != nil {
+		return nil, fmt.Errorf("could not decode getRecord response: %w", err)
+	}
+	return &rec, nil
+}
+
+// permissionsFromRecord converts a permission-set Lexicon record into the list
+// of concrete permissions it grants. Unknown resource types and unknown fields
+// are ignored for forward compatibility, per the permission-set spec.
+func permissionsFromRecord(rec *getRecordResponse, params url.Values) ([]Permission, error) {
+	main := rec.Value.Defs.Main
+	if main.Type != "permission-set" {
+		return nil, fmt.Errorf("record is not a permission-set (defs.main.type=%q)", main.Type)
+	}
+
+	includeAud := ""
+	if params != nil {
+		includeAud = params.Get("aud")
+	}
+
+	var perms []Permission
+	for _, item := range main.Permissions {
+		switch item.Resource {
+		case "repo":
+			for _, col := range item.Collection {
+				p := Permission{Resource: "repo", Positional: col, Params: url.Values{}}
+				for _, a := range item.Action {
+					p.Params.Add("action", a)
+				}
+				perms = append(perms, p)
+			}
+		case "blob":
+			p := Permission{Resource: "blob", Params: url.Values{}}
+			for _, a := range item.Accept {
+				p.Params.Add("accept", a)
+			}
+			perms = append(perms, p)
+		case "rpc":
+			aud := item.Aud
+			if item.InheritAud {
+				// Per spec: inheritAud with no include aud, or combined with an
+				// explicit aud, is invalid and the permission is ignored.
+				if includeAud == "" || item.Aud != "" {
+					continue
+				}
+				aud = includeAud
+			}
+			for _, lxm := range item.Lxm {
+				p := Permission{Resource: "rpc", Positional: lxm, Params: url.Values{}}
+				if aud != "" {
+					p.Params.Set("aud", aud)
+				}
+				perms = append(perms, p)
+			}
+		default:
+			// Ignore unknown resource types for forward compatibility.
+		}
+	}
+
+	return perms, nil
+}

--- a/oauth/scopes/permission_set_test.go
+++ b/oauth/scopes/permission_set_test.go
@@ -1,0 +1,123 @@
+package scopes
+
+import (
+	"net/url"
+	"testing"
+)
+
+const sampleAuthFull = `{
+  "uri": "at://did:web:example.com/com.atproto.lexicon.schema/com.example.authFull",
+  "cid": "bafyreigabc",
+  "value": {
+    "lexicon": 1,
+    "id": "com.example.authFull",
+    "defs": {
+      "main": {
+        "type": "permission-set",
+        "title": "Full Access",
+        "permissions": [
+          { "type": "permission", "resource": "repo", "collection": ["app.example.post"] },
+          { "type": "permission", "resource": "repo", "collection": ["app.example.like"], "action": ["create", "delete"] },
+          { "type": "permission", "resource": "blob", "accept": ["image/*"] },
+          { "type": "permission", "resource": "rpc", "inheritAud": true, "lxm": ["app.example.getFeed"] },
+          { "type": "permission", "resource": "rpc", "aud": "did:web:fixed.example.com", "lxm": ["app.example.ping"] }
+        ]
+      }
+    }
+  }
+}`
+
+func TestPermissionsFromRecord(t *testing.T) {
+	rec, err := parseRecordJSON([]byte(sampleAuthFull))
+	if err != nil {
+		t.Fatalf("parseRecordJSON: %v", err)
+	}
+
+	params := url.Values{}
+	params.Set("aud", "did:web:caller.example.com")
+
+	perms, err := permissionsFromRecord(rec, params)
+	if err != nil {
+		t.Fatalf("permissionsFromRecord: %v", err)
+	}
+
+	// repo:app.example.post (no action) -> any action allowed
+	if !RepoWriteAllowed(perms, "app.example.post", "create") {
+		t.Errorf("expected create allowed on app.example.post")
+	}
+	if !RepoWriteAllowed(perms, "app.example.post", "delete") {
+		t.Errorf("expected delete allowed on app.example.post (no action filter)")
+	}
+
+	// repo:app.example.like with action=[create,delete]
+	if !RepoWriteAllowed(perms, "app.example.like", "create") {
+		t.Errorf("expected create allowed on app.example.like")
+	}
+	if RepoWriteAllowed(perms, "app.example.like", "update") {
+		t.Errorf("did not expect update allowed on app.example.like (action filtered)")
+	}
+
+	// collection not in the set
+	if RepoWriteAllowed(perms, "app.example.other", "create") {
+		t.Errorf("did not expect create allowed on unlisted collection")
+	}
+
+	// blob
+	if !BlobAllowed(perms) {
+		t.Errorf("expected blob allowed")
+	}
+
+	// rpc with inheritAud should pick up the caller's aud
+	var inheritedAud, fixedAud string
+	for _, p := range perms {
+		if p.Resource == "rpc" && p.Positional == "app.example.getFeed" {
+			inheritedAud = p.Params.Get("aud")
+		}
+		if p.Resource == "rpc" && p.Positional == "app.example.ping" {
+			fixedAud = p.Params.Get("aud")
+		}
+	}
+	if inheritedAud != "did:web:caller.example.com" {
+		t.Errorf("inheritAud rpc: got aud %q, want caller aud", inheritedAud)
+	}
+	if fixedAud != "did:web:fixed.example.com" {
+		t.Errorf("fixed-aud rpc: got aud %q, want fixed aud", fixedAud)
+	}
+}
+
+func TestPermissionsFromRecordInheritAudMissing(t *testing.T) {
+	rec, err := parseRecordJSON([]byte(sampleAuthFull))
+	if err != nil {
+		t.Fatalf("parseRecordJSON: %v", err)
+	}
+
+	// No aud supplied by the include: the inheritAud rpc permission must be
+	// dropped, while the fixed-aud one survives.
+	perms, err := permissionsFromRecord(rec, url.Values{})
+	if err != nil {
+		t.Fatalf("permissionsFromRecord: %v", err)
+	}
+
+	for _, p := range perms {
+		if p.Resource == "rpc" && p.Positional == "app.example.getFeed" {
+			t.Errorf("inheritAud rpc with no include aud should be dropped")
+		}
+	}
+}
+
+func TestPermissionsFromRecordWrongType(t *testing.T) {
+	const notPermSet = `{"value":{"defs":{"main":{"type":"record"}}}}`
+	rec, err := parseRecordJSON([]byte(notPermSet))
+	if err != nil {
+		t.Fatalf("parseRecordJSON: %v", err)
+	}
+	if _, err := permissionsFromRecord(rec, nil); err == nil {
+		t.Errorf("expected error for non-permission-set record")
+	}
+}
+
+func TestParseRecordJSONInvalid(t *testing.T) {
+	if _, err := parseRecordJSON([]byte("not json")); err == nil {
+		t.Errorf("expected error for invalid JSON")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/haileyok/cocoon/oauth/constants"
 	"github.com/haileyok/cocoon/oauth/dpop"
 	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/haileyok/cocoon/oauth/scopes"
 	"github.com/haileyok/cocoon/plc"
 	"github.com/ipfs/go-cid"
 	"github.com/labstack/echo-contrib/echoprometheus"
@@ -77,6 +78,7 @@ type Server struct {
 	privateKey    *ecdsa.PrivateKey
 	repoman       *RepoMan
 	oauthProvider *provider.Provider
+	scopeResolver *scopes.Resolver
 	evtman        *events.EventManager
 	passport      *identity.Passport
 	fallbackProxy string
@@ -434,6 +436,8 @@ func New(args *Args) (*Server, error) {
 			BlockstoreVariant: args.BlockstoreVariant,
 			FallbackProxy:     args.FallbackProxy,
 		},
+		scopeResolver: scopes.NewResolver(oauthCli),
+
 		evtman:   events.NewEventManager(evtPersister),
 		passport: identity.NewPassport(h, identity.NewMemCache(10_000)),
 


### PR DESCRIPTION
## Summary
Adds `scopes.Resolver`, which resolves `include:<nsid>` scope references to their concrete permissions by following the atproto Lexicon resolution chain. Wires a resolver onto `Server`. Not yet used for enforcement, so still low-risk.

## Related Issues/Tasks
Foundation for OAuth conformance fixes #2 and #3.

## Changes Made
- `oauth/scopes/permission_set.go`: `Resolver` with positive + short-TTL negative caching. `Resolve`/`ValidateInclude` perform: NSID authority -> DID via `_lexicon.<authority>` DNS TXT (`did=`), DID -> PDS, fetch `com.atproto.lexicon.schema` record (rkey=nsid), require `defs.main.type == "permission-set"`, and expand `permissions[]` (repo/blob/rpc, including `inheritAud`) into scope `Permission`s. Unknown resources/fields ignored for forward-compat.
- `oauth/scopes/permission_set_test.go`: pure JSON->permissions tests incl. inheritAud and wrong-type handling.
- `identity/identity.go`: adds `ResolveLexiconAuthority`.
- `server/server.go`: constructs and stores a `*scopes.Resolver` (reusing the oauth HTTP client).

## Confidence Level
Confidence Level: Claude

## Testing
`go test ./oauth/scopes/...` passes; `go build ./...`, `go vet ./...` pass.

## Notes
PR 4/7 in a stacked series. Base is `pr3-scopes-parser`.