### PR TITLE
[oauth] Validate requested scopes; reject unresolvable include:

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -81,6 +81,11 @@ func InvalidRequestOauthError(e echo.Context, desc string) error {
 	return OauthError(e, 400, "invalid_request", desc)
 }
 
+// InvalidScopeError responds with a 400 "invalid_scope" OAuth error.
+func InvalidScopeError(e echo.Context, desc string) error {
+	return OauthError(e, 400, "invalid_scope", desc)
+}
+
 // OauthInvalidTokenError responds with a 401 "invalid_token" error plus the
 // DPoP WWW-Authenticate challenge required by RFC 6750 / RFC 9449. Used by the
 // resource server when a presented access token is unknown or has been revoked.

--- a/server/handle_oauth_authorize.go
+++ b/server/handle_oauth_authorize.go
@@ -77,6 +77,12 @@ func (s *Server) handleOauthAuthorizeGet(e echo.Context) error {
 			return helpers.InvalidRequestOauthError(e, "redirect_uri is not registered for this client")
 		}
 
+		// Validate the requested scopes, resolving any include: permission sets.
+		if err := s.validateRequestedScopes(ctx, parRequest.Scope); err != nil {
+			s.logger.Error("invalid requested scope", "client_id", parRequest.ClientID, "scope", parRequest.Scope, "error", err)
+			return helpers.InvalidScopeError(e, err.Error())
+		}
+
 		if parRequest.DpopJkt == nil {
 			if client.Metadata.DpopBoundAccessTokens {
 			}

--- a/server/handle_oauth_par.go
+++ b/server/handle_oauth_par.go
@@ -69,6 +69,12 @@ func (s *Server) handleOauthPar(e echo.Context) error {
 		return helpers.InvalidRequestOauthError(e, "redirect_uri is not registered for this client")
 	}
 
+	// Validate the requested scopes, resolving any include: permission sets.
+	if err := s.validateRequestedScopes(ctx, parRequest.Scope); err != nil {
+		logger.Error("invalid requested scope", "client_id", parRequest.ClientID, "scope", parRequest.Scope, "error", err)
+		return helpers.InvalidScopeError(e, err.Error())
+	}
+
 	if parRequest.DpopJkt == nil {
 		if client.Metadata.DpopBoundAccessTokens {
 			parRequest.DpopJkt = to.StringPtr(dpopProof.JKT)

--- a/server/oauth_scope_validation.go
+++ b/server/oauth_scope_validation.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/haileyok/cocoon/oauth/scopes"
+)
+
+// validateRequestedScopes validates an OAuth authorization request's scope
+// string. It returns an error (to be surfaced as invalid_scope) when the scope
+// cannot be parsed, is missing the required `atproto` scope, or contains an
+// `include:` reference to a permission set that cannot be resolved.
+//
+// Unknown non-include resources are intentionally accepted for forward and
+// backward compatibility; this function does not attempt to reject them.
+func (s *Server) validateRequestedScopes(ctx context.Context, scope string) error {
+	perms, err := scopes.Parse(scope)
+	if err != nil {
+		return fmt.Errorf("could not parse scope: %w", err)
+	}
+
+	if !scopes.Has(perms, "atproto") {
+		return errors.New("the `atproto` scope is required")
+	}
+
+	for _, p := range perms {
+		if p.Resource != "include" {
+			continue
+		}
+		if p.Positional == "" {
+			return errors.New("`include` scope requires a permission-set nsid")
+		}
+		if err := s.scopeResolver.ValidateInclude(ctx, p.Positional, p.Params); err != nil {
+			return fmt.Errorf("invalid include `%s`: %w", p.Positional, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
PAR and the standard authorize branch now validate the requested scope string and reject `include:<nsid>` references that don't resolve to a real permission set with `400 invalid_scope`. Fixes the `flow.par-rejects-invalid-include` conformance failure.

## Related Issues/Tasks
OAuth conformance failure (#2 par-rejects-invalid-include).

## Changes Made
- `server/oauth_scope_validation.go`: `validateRequestedScopes` — scope must parse, must contain `atproto`, and every `include:` must resolve via the resolver. Unknown non-include resources are accepted (forward/backward compat).
- `server/handle_oauth_par.go` and `server/handle_oauth_authorize.go`: call it before persisting the authorization request.
- `internal/helpers/helpers.go`: adds `InvalidScopeError`.

## Confidence Level
Confidence Level: Claude

## Testing
`go build ./...`, `go vet ./...` pass.

## Notes
PR 5/7 in a stacked series. Base is `pr4-include-resolver`. Depends on the scopes package + resolver. Note: validation does a live network resolution at PAR time, mitigated by caching in the resolver.