### PR TITLE
[oauth] Enforce granular repo write scopes

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -86,6 +86,17 @@ func InvalidScopeError(e echo.Context, desc string) error {
 	return OauthError(e, 400, "invalid_scope", desc)
 }
 
+// InsufficientScopeError responds with a 403 "insufficient_scope" error and the
+// DPoP WWW-Authenticate challenge required by RFC 6750 3.1, used when a valid
+// access token lacks the granular permission needed for the request.
+func InsufficientScopeError(e echo.Context) error {
+	e.Response().Header().Set("WWW-Authenticate", "DPoP error=\"insufficient_scope\"")
+	e.Response().Header().Add("access-control-expose-headers", "WWW-Authenticate")
+	return e.JSON(403, map[string]string{
+		"error": "insufficient_scope",
+	})
+}
+
 // OauthInvalidTokenError responds with a 401 "invalid_token" error plus the
 // DPoP WWW-Authenticate challenge required by RFC 6750 / RFC 9449. Used by the
 // resource server when a presented access token is unknown or has been revoked.

--- a/server/enforce_repo_write.go
+++ b/server/enforce_repo_write.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"context"
+	"strings"
+
+	"github.com/haileyok/cocoon/internal/helpers"
+	"github.com/haileyok/cocoon/oauth/scopes"
+	"github.com/labstack/echo/v4"
+)
+
+// requestScopes returns the parsed permissions for the current request and
+// whether granular scope enforcement applies to it. Enforcement only applies
+// when the OAuth/DPoP session middleware set "scopes" on the context; legacy
+// bearer JWTs and inter-service auth leave it unset and are unaffected. If the
+// stored scope string somehow fails to parse, enforcement still applies with an
+// empty permission set (fail closed) — the scope was already validated at
+// authorization time, so this should not happen for legitimate tokens.
+func (s *Server) requestScopes(e echo.Context) ([]scopes.Permission, bool) {
+	raw := e.Get("scopes")
+	if raw == nil {
+		return nil, false
+	}
+	rawScopes, ok := raw.([]string)
+	if !ok {
+		return nil, false
+	}
+	perms, err := scopes.Parse(strings.Join(rawScopes, " "))
+	if err != nil {
+		return nil, true
+	}
+	return perms, true
+}
+
+// expandIncludes appends the permissions granted by any include: references to
+// the supplied set. Resolution failures are logged and treated as granting
+// nothing (so they neither 500 nor silently widen access).
+func (s *Server) expandIncludes(ctx context.Context, perms []scopes.Permission) []scopes.Permission {
+	expanded := perms
+	for _, p := range perms {
+		if p.Resource != "include" || p.Positional == "" {
+			continue
+		}
+		resolved, err := s.scopeResolver.Resolve(ctx, p.Positional, p.Params)
+		if err != nil {
+			s.logger.Warn("could not resolve include scope for write enforcement", "nsid", p.Positional, "error", err)
+			continue
+		}
+		expanded = append(expanded, resolved...)
+	}
+	return expanded
+}
+
+// enforceRepoWrite ensures the current request's granted scopes permit every
+// listed action on the given collection. It is a no-op for non-OAuth sessions
+// and for the legacy transition:generic scope. On failure it returns a 403
+// insufficient_scope error.
+func (s *Server) enforceRepoWrite(e echo.Context, ctx context.Context, collection string, actions ...string) error {
+	perms, enforce := s.requestScopes(e)
+	if !enforce || scopes.GrantsAllRepoWrites(perms) {
+		return nil
+	}
+
+	perms = s.expandIncludes(ctx, perms)
+
+	for _, action := range actions {
+		if !scopes.RepoWriteAllowed(perms, collection, action) {
+			return helpers.InsufficientScopeError(e)
+		}
+	}
+
+	return nil
+}
+
+// enforceBlobUpload ensures the current request's granted scopes permit blob
+// uploads. It is a no-op for non-OAuth sessions and for transition:generic.
+func (s *Server) enforceBlobUpload(e echo.Context, ctx context.Context) error {
+	perms, enforce := s.requestScopes(e)
+	if !enforce || scopes.GrantsAllRepoWrites(perms) {
+		return nil
+	}
+
+	perms = s.expandIncludes(ctx, perms)
+
+	if !scopes.BlobAllowed(perms) {
+		return helpers.InsufficientScopeError(e)
+	}
+
+	return nil
+}
+
+// applyWriteAction maps a com.atproto.repo.applyWrites item $type to the repo
+// action it performs. Returns "" for unrecognized types.
+func applyWriteAction(t string) string {
+	switch t {
+	case "com.atproto.repo.applyWrites#create":
+		return "create"
+	case "com.atproto.repo.applyWrites#update":
+		return "update"
+	case "com.atproto.repo.applyWrites#delete":
+		return "delete"
+	default:
+		return ""
+	}
+}

--- a/server/handle_repo_apply_writes.go
+++ b/server/handle_repo_apply_writes.go
@@ -47,6 +47,18 @@ func (s *Server) handleApplyWrites(e echo.Context) error {
 		return helpers.InputError(e, nil)
 	}
 
+	// Enforce granular write scopes per item; if any item is out of scope the
+	// entire batch is rejected before any writes are applied.
+	for _, item := range req.Writes {
+		action := applyWriteAction(item.Type)
+		if action == "" {
+			continue
+		}
+		if err := s.enforceRepoWrite(e, ctx, item.Collection, action); err != nil {
+			return err
+		}
+	}
+
 	ops := make([]Op, 0, len(req.Writes))
 	for _, item := range req.Writes {
 		ops = append(ops, Op{

--- a/server/handle_repo_create_record.go
+++ b/server/handle_repo_create_record.go
@@ -39,8 +39,14 @@ func (s *Server) handleCreateRecord(e echo.Context) error {
 	}
 
 	optype := OpTypeCreate
+	action := "create"
 	if req.SwapRecord != nil {
 		optype = OpTypeUpdate
+		action = "update"
+	}
+
+	if err := s.enforceRepoWrite(e, ctx, req.Collection, action); err != nil {
+		return err
 	}
 
 	results, err := s.repoman.applyWrites(ctx, repo.Repo, []Op{

--- a/server/handle_repo_delete_record.go
+++ b/server/handle_repo_delete_record.go
@@ -36,6 +36,10 @@ func (s *Server) handleDeleteRecord(e echo.Context) error {
 		return helpers.InputError(e, nil)
 	}
 
+	if err := s.enforceRepoWrite(e, ctx, req.Collection, "delete"); err != nil {
+		return err
+	}
+
 	results, err := s.repoman.applyWrites(ctx, repo.Repo, []Op{
 		{
 			Type:       OpTypeDelete,

--- a/server/handle_repo_put_record.go
+++ b/server/handle_repo_put_record.go
@@ -38,6 +38,12 @@ func (s *Server) handlePutRecord(e echo.Context) error {
 		return helpers.InputError(e, nil)
 	}
 
+	// putRecord is an upsert, so it requires both create and update permission
+	// for the collection (matching the reference PDS).
+	if err := s.enforceRepoWrite(e, ctx, req.Collection, "create", "update"); err != nil {
+		return err
+	}
+
 	optype := OpTypeCreate
 	if req.SwapRecord != nil {
 		optype = OpTypeUpdate

--- a/server/handle_repo_upload_blob.go
+++ b/server/handle_repo_upload_blob.go
@@ -37,6 +37,10 @@ func (s *Server) handleRepoUploadBlob(e echo.Context) error {
 
 	urepo := e.Get("repo").(*models.RepoActor)
 
+	if err := s.enforceBlobUpload(e, ctx); err != nil {
+		return err
+	}
+
 	mime := e.Request().Header.Get("content-type")
 	if mime == "" {
 		mime = "application/octet-stream"


### PR DESCRIPTION
## Summary
Enforces granular `repo:` (and `blob`) write scopes on the repo mutation endpoints, returning `403 insufficient_scope` when a token writes outside its granted scope. Fixes the `flow.boundary-write-out-of-scope` conformance failure.

## Related Issues/Tasks
OAuth conformance failure (#3 boundary-write-out-of-scope).

## Changes Made
- `server/enforce_repo_write.go`: `enforceRepoWrite` / `enforceBlobUpload`, include-expansion (cached), and `$type`->action mapping. Enforcement only applies when the OAuth/DPoP middleware set `scopes` on the request; legacy bearer/service-auth and `transition:generic` are unaffected.
- Wired into `createRecord` (create), `putRecord` (create+update), `deleteRecord` (delete), `applyWrites` (per-item, whole-batch rejection) and `uploadBlob` (blob). Required actions match the reference PDS.
- `internal/helpers/helpers.go`: adds `InsufficientScopeError` (403 + DPoP challenge).

## Confidence Level
Confidence Level: Claude

## Testing
`go build ./...`, `go vet ./...` pass.

## Notes
PR 6/7 in a stacked series. Base is `pr5-scope-validation`.