### PR TITLE
[oauth] Implement RFC 7662 token introspection endpoint

### DIFF
--- a/server/handle_oauth_introspect.go
+++ b/server/handle_oauth_introspect.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"errors"
+	"time"
+
+	"github.com/haileyok/cocoon/internal/helpers"
+	"github.com/haileyok/cocoon/oauth/dpop"
+	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/labstack/echo/v4"
+)
+
+// OauthIntrospectRequest is the body of an RFC 7662 token introspection request.
+type OauthIntrospectRequest struct {
+	provider.AuthenticateClientRequestBase
+	Token         string `form:"token" json:"token" query:"token"`
+	TokenTypeHint string `form:"token_type_hint" json:"token_type_hint" query:"token_type_hint"`
+}
+
+// handleOauthIntrospect implements the RFC 7662 token introspection endpoint
+// advertised in the authorization-server metadata. The client is authenticated
+// and asked about a token it was issued. Active tokens return their claims;
+// unknown, expired, or revoked tokens return {"active": false}.
+func (s *Server) handleOauthIntrospect(e echo.Context) error {
+	ctx := e.Request().Context()
+	logger := s.logger.With("name", "handleOauthIntrospect")
+
+	var req OauthIntrospectRequest
+	if err := e.Bind(&req); err != nil {
+		logger.Error("error binding introspect request", "error", err)
+		return helpers.InvalidRequestOauthError(e, "could not parse request")
+	}
+
+	// DPoP is optional here, mirroring the token/revoke endpoints.
+	proof, err := s.oauthProvider.DpopManager.CheckProof(e.Request().Method, e.Request().URL.String(), e.Request().Header, nil)
+	if err != nil {
+		if errors.Is(err, dpop.ErrUseDpopNonce) {
+			nonce := s.oauthProvider.NextNonce()
+			if nonce != "" {
+				e.Response().Header().Set("DPoP-Nonce", nonce)
+				e.Response().Header().Add("access-control-expose-headers", "DPoP-Nonce")
+			}
+			return e.JSON(400, map[string]string{
+				"error": "use_dpop_nonce",
+			})
+		}
+		logger.Error("error checking dpop proof", "error", err)
+		return helpers.InvalidRequestOauthError(e, "invalid dpop proof")
+	}
+
+	client, _, err := s.oauthProvider.AuthenticateClient(ctx, req.AuthenticateClientRequestBase, proof, &provider.AuthenticateClientOptions{
+		AllowMissingDpopProof: true,
+	})
+	if err != nil {
+		logger.Error("error authenticating client", "client_id", req.ClientID, "error", err)
+		return helpers.InvalidRequestOauthError(e, err.Error())
+	}
+
+	inactive := map[string]any{"active": false}
+
+	if req.Token == "" {
+		return e.JSON(200, inactive)
+	}
+
+	// Only reveal tokens that were issued to the requesting client.
+	var oauthToken provider.OauthToken
+	if err := s.db.Raw(ctx, "SELECT * FROM oauth_tokens WHERE client_id = ? AND (token = ? OR refresh_token = ?)", nil, client.Metadata.ClientID, req.Token, req.Token).Scan(&oauthToken).Error; err != nil {
+		logger.Error("error looking up token", "error", err)
+		return helpers.ServerError(e, nil)
+	}
+
+	if oauthToken.Token == "" || time.Now().After(oauthToken.ExpiresAt) {
+		return e.JSON(200, inactive)
+	}
+
+	tokenType := "Bearer"
+	if oauthToken.Parameters.DpopJkt != nil {
+		tokenType = "DPoP"
+	}
+
+	return e.JSON(200, map[string]any{
+		"active":     true,
+		"scope":      oauthToken.Parameters.Scope,
+		"client_id":  oauthToken.ClientId,
+		"token_type": tokenType,
+		"sub":        oauthToken.Sub,
+		"aud":        s.config.Did,
+		"iat":        oauthToken.CreatedAt.Unix(),
+		"exp":        oauthToken.ExpiresAt.Unix(),
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -541,6 +541,7 @@ func (s *Server) addRoutes() {
 	s.echo.POST("/oauth/par", s.handleOauthPar, s.oauthProvider.BaseMiddleware)
 	s.echo.POST("/oauth/token", s.handleOauthToken, s.oauthProvider.BaseMiddleware)
 	s.echo.POST("/oauth/revoke", s.handleOauthRevoke, s.oauthProvider.BaseMiddleware)
+	s.echo.POST("/oauth/introspect", s.handleOauthIntrospect, s.oauthProvider.BaseMiddleware)
 
 	// authed
 	s.echo.GET("/xrpc/com.atproto.server.getSession", s.handleGetSession, s.handleLegacySessionMiddleware, s.handleOauthSessionMiddleware)


### PR DESCRIPTION
## Summary
The authorization-server metadata advertised `introspection_endpoint` with no route registered. Adds a minimal RFC 7662 `POST /oauth/introspect` so the advertised endpoints all resolve. Not one of the 5 conformance failures, but removes a metadata/route inconsistency.

## Related Issues/Tasks
Optional cleanup alongside the OAuth conformance fixes (PR 7/7).

## Changes Made
- New `server/handle_oauth_introspect.go`: authenticates the client (DPoP optional), then returns `{active:true,...claims}` for a live token issued to that client, or `{active:false}` for unknown/expired/revoked tokens.
- Registered the route in `server/server.go`.

## Confidence Level
Confidence Level: Claude

## Testing
`go build ./...`, `go vet ./...` pass.

## Notes
PR 7/7 in a stacked series. Base is `pr6-repo-write-enforcement`.