### PR TITLE
fix: validate aud on service-auth tokens

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -74,6 +74,11 @@ func (s *Server) handleLegacySessionMiddleware(next echo.HandlerFunc) echo.Handl
 				return helpers.InputError(e, nil)
 			}
 
+			if aud, _ := claims["aud"].(string); aud != s.config.Did {
+				logger.Error("service auth aud incorrect", "aud", aud, "expected", s.config.Did)
+				return helpers.InputError(e, nil)
+			}
+
 			maybeDid, ok := claims["iss"].(string)
 			if !ok {
 				logger.Error("no iss in service auth token", "error", err)

--- a/server/service_auth.go
+++ b/server/service_auth.go
@@ -84,8 +84,21 @@ func (s *Server) validateServiceAuth(ctx context.Context, rawToken string, nsid 
 	}
 
 	claims := parsedToken.Claims.(jwt.MapClaims)
-	if claims["lxm"] != nsid {
-		return "", fmt.Errorf("bad jwt lexicon method (\"lxm\"). must match: %s", nsid)
+	if err := validateServiceAuthClaims(claims, s.config.Did, nsid); err != nil {
+		return "", err
 	}
 	return claims["iss"].(string), nil
+}
+
+// validateServiceAuthClaims enforces that a service-auth JWT is addressed to
+// this PDS (aud) and scoped to the expected lexicon method (lxm). Without the
+// aud check a token a user minted for another service could be replayed here.
+func validateServiceAuthClaims(claims jwt.MapClaims, expectedAud, expectedLxm string) error {
+	if lxm, _ := claims["lxm"].(string); lxm != expectedLxm {
+		return fmt.Errorf("bad jwt lexicon method (\"lxm\"). must match: %s", expectedLxm)
+	}
+	if aud, _ := claims["aud"].(string); aud != expectedAud {
+		return fmt.Errorf("bad jwt audience (\"aud\"). must match: %s", expectedAud)
+	}
+	return nil
 }

--- a/server/service_auth_test.go
+++ b/server/service_auth_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/labstack/echo/v4"
+	secp256k1secec "gitlab.com/yawning/secp256k1-voi/secec"
+)
+
+// mintServiceAuthToken builds an ES256K service-auth JWT signed with the given
+// raw k256 key, mirroring how handleServerGetServiceAuth signs tokens.
+func mintServiceAuthToken(t *testing.T, signingKey []byte, iss, aud, lxm string, exp time.Time) string {
+	t.Helper()
+
+	header, _ := json.Marshal(map[string]string{"alg": "ES256K", "typ": "JWT"})
+	payload, _ := json.Marshal(map[string]any{
+		"iss": iss,
+		"aud": aud,
+		"lxm": lxm,
+		"iat": time.Now().Unix(),
+		"exp": exp.Unix(),
+		"jti": "test-jti",
+	})
+
+	input := base64.RawURLEncoding.EncodeToString(header) + "." + base64.RawURLEncoding.EncodeToString(payload)
+	hash := sha256.Sum256([]byte(input))
+
+	sk, err := secp256k1secec.NewPrivateKey(signingKey)
+	if err != nil {
+		t.Fatalf("load signing key: %v", err)
+	}
+	R, S, _, err := sk.SignRaw(rand.Reader, hash[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	rBytes, sBytes := R.Bytes(), S.Bytes()
+	rawsig := make([]byte, 64)
+	copy(rawsig[32-len(rBytes):32], rBytes)
+	copy(rawsig[64-len(sBytes):], sBytes)
+
+	return input + "." + base64.RawURLEncoding.EncodeToString(rawsig)
+}
+
+func TestValidateServiceAuthClaims(t *testing.T) {
+	const (
+		wantAud = "did:web:pds.test"
+		wantLxm = "com.atproto.server.createAccount"
+	)
+
+	tests := []struct {
+		name    string
+		claims  jwt.MapClaims
+		wantErr bool
+	}{
+		{"valid", jwt.MapClaims{"aud": wantAud, "lxm": wantLxm}, false},
+		{"wrong aud", jwt.MapClaims{"aud": "did:web:evil.example", "lxm": wantLxm}, true},
+		{"missing aud", jwt.MapClaims{"lxm": wantLxm}, true},
+		{"wrong lxm", jwt.MapClaims{"aud": wantAud, "lxm": "com.atproto.repo.createRecord"}, true},
+		{"missing lxm", jwt.MapClaims{"aud": wantAud}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServiceAuthClaims(tt.claims, wantAud, wantLxm)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateServiceAuthClaims err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestLegacyMiddlewareServiceAuthAud exercises the service-auth path of the
+// legacy session middleware: a token whose aud does not equal this PDS's DID
+// must be rejected; one with the correct aud must pass through.
+func TestLegacyMiddlewareServiceAuthAud(t *testing.T) {
+	const lxm = "com.atproto.repo.createRecord"
+	target := "/xrpc/" + lxm
+
+	run := func(t *testing.T, aud string) (called bool, code int) {
+		s := newTestServer(t)
+		acct := s.createTestAccount(t, "alice.pds.test")
+
+		next := func(c echo.Context) error {
+			called = true
+			return c.String(http.StatusOK, "ok")
+		}
+
+		tok := mintServiceAuthToken(t, acct.SigningKey, acct.Did, aud, lxm, time.Now().Add(time.Minute))
+		c, rec := newRequestContext(http.MethodPost, target, "", map[string]string{
+			"authorization": "Bearer " + tok,
+		})
+
+		if err := s.handleLegacySessionMiddleware(next)(c); err != nil {
+			c.Error(err)
+		}
+		return called, rec.Code
+	}
+
+	t.Run("wrong aud rejected", func(t *testing.T) {
+		called, code := run(t, "did:web:evil.example")
+		if called {
+			t.Fatal("next handler was reached for a token addressed to a different service")
+		}
+		if code == http.StatusOK {
+			t.Fatalf("expected rejection status, got %d", code)
+		}
+	})
+
+	t.Run("correct aud allowed", func(t *testing.T) {
+		called, code := run(t, testDid)
+		if !called {
+			t.Fatal("next handler was not reached for a correctly-addressed token")
+		}
+		if code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", code)
+		}
+	})
+}


### PR DESCRIPTION
> Base is `hailey/fix-test-harness` (the shared test harness, PR #92). Retarget to `main` once that merges.

## Bug (High)

Service-auth JWTs were verified for signature, `lxm`, and `exp` but **never for `aud`**. Per atproto, a service-auth token's `aud` must equal the receiving service's DID. Because cocoon skipped that check:

- `validateServiceAuth` (`server/service_auth.go`, used by `createAccount`) and
- the legacy session middleware's service-auth branch (`server/middleware.go`)

…would both accept a token a user legitimately minted (via `getServiceAuth`) for **some other** service, replayed back to this PDS as that user for the matching lexicon method. Classic confused-deputy / replay primitive.

## Fix

- Extract `validateServiceAuthClaims(claims, expectedAud, expectedLxm)` and require `aud == s.config.Did` alongside the existing `lxm` check in `validateServiceAuth`.
- Add the same `aud == s.config.Did` check to the middleware's `hasLxm` service-auth branch.

## Tests

- `TestValidateServiceAuthClaims` — table test: valid / wrong aud / missing aud / wrong lxm / missing lxm.
- `TestLegacyMiddlewareServiceAuthAud` — end-to-end through the middleware with a real ES256K-signed token: wrong `aud` is rejected, correct `aud` passes to the next handler.

## Verification

`gofmt` clean, `go vet ./server/` clean, `go test ./server/` passes.