### PR TITLE
fix: make session access tokens revocable

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -172,7 +172,10 @@ func (s *Server) handleLegacySessionMiddleware(next echo.HandlerFunc) echo.Handl
 			table = "refresh_tokens"
 		}
 
-		if isRefresh {
+		// session tokens (access and refresh) must still exist in the db, so that
+		// signout and refresh rotation actually revoke them. service-auth tokens
+		// (lxm) are stateless and are not tracked there.
+		if !hasLxm {
 			type Result struct {
 				Found bool
 			}

--- a/server/middleware_revocation_test.go
+++ b/server/middleware_revocation_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// runAccessMiddleware drives handleLegacySessionMiddleware for a bearer access
+// token against a non-refresh protected route, reporting whether the wrapped
+// handler ran and the resulting status code.
+func runAccessMiddleware(t *testing.T, s *Server, token string) (called bool, code int) {
+	t.Helper()
+
+	next := func(c echo.Context) error {
+		called = true
+		return c.String(http.StatusOK, "ok")
+	}
+
+	c, rec := newRequestContext(http.MethodGet, "/xrpc/com.atproto.server.getSession", "", map[string]string{
+		"authorization": "Bearer " + token,
+	})
+	if err := s.handleLegacySessionMiddleware(next)(c); err != nil {
+		c.Error(err)
+	}
+	return called, rec.Code
+}
+
+// TestLegacyMiddlewareAccessTokenRevocation verifies that deleting a session's
+// access-token row (as signout / refresh rotation do) actually invalidates the
+// access JWT, rather than leaving it usable until expiry.
+func TestLegacyMiddlewareAccessTokenRevocation(t *testing.T) {
+	ctx := context.Background()
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+
+	ra, err := s.getRepoActorByDid(ctx, acct.Did)
+	if err != nil {
+		t.Fatalf("load repo: %v", err)
+	}
+
+	sess, err := s.createSession(ctx, &ra.Repo)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	t.Run("live access token accepted", func(t *testing.T) {
+		called, code := runAccessMiddleware(t, s, sess.AccessToken)
+		if !called {
+			t.Fatal("next handler not reached for a live session")
+		}
+		if code != http.StatusOK {
+			t.Fatalf("got status %d, want 200", code)
+		}
+	})
+
+	t.Run("revoked access token rejected", func(t *testing.T) {
+		if err := s.db.Exec(ctx, "DELETE FROM tokens WHERE token = ?", nil, sess.AccessToken).Error; err != nil {
+			t.Fatalf("delete token row: %v", err)
+		}
+
+		called, code := runAccessMiddleware(t, s, sess.AccessToken)
+		if called {
+			t.Fatal("next handler reached for a revoked access token")
+		}
+		if code == http.StatusOK {
+			t.Fatalf("expected rejection status, got %d", code)
+		}
+	})
+}


### PR DESCRIPTION
## Bug (High)

The legacy session middleware only verified the **refresh** token against the database; **access** JWTs were accepted on signature + `exp` alone (`server/middleware.go`). Since `deleteSession` (signout) and `refreshSession` (rotation) only delete the `tokens`/`refresh_tokens` rows, a revoked/rotated/stolen access token kept authenticating to protected endpoints for up to its 3-hour lifetime. Logout did not actually end access.

## Fix

Gate the existing token-existence check on `!hasLxm` instead of `isRefresh`, so it covers session **access** tokens as well as refresh tokens (`table` already resolves to `tokens` vs `refresh_tokens`). Service-auth (`lxm`) tokens are stateless and correctly skip the check.

No functional regression: genuine session access tokens are written to `tokens` by `createSession`, so live sessions still pass. No-`lxm` service-auth tokens were already rejected earlier by the scope check, so they don't reach this path.

## Tests

`TestLegacyMiddlewareAccessTokenRevocation`:
- a live access token is accepted;
- after deleting its `tokens` row (as signout/refresh do), the same token is rejected.

Confirmed red before the fix (revoked token reached the handler), green after.

## Verification

`gofmt` clean, `go vet ./server/` clean, `go test ./server/` passes.