### PR TITLE
fix: consume invite codes atomically to close signup race

### DIFF
--- a/server/common.go
+++ b/server/common.go
@@ -40,6 +40,18 @@ func (s *Server) getRepoActorByEmail(ctx context.Context, email string) (*models
 	return &repo, nil
 }
 
+// consumeInviteCode atomically claims one use of an invite code. It returns
+// false when the code does not exist or has no remaining uses. The conditional
+// update guarantees a single-use code can be consumed at most once, even under
+// concurrent createAccount requests, and never drives the count below zero.
+func (s *Server) consumeInviteCode(ctx context.Context, code string) (bool, error) {
+	res := s.db.Exec(ctx, "UPDATE invite_codes SET remaining_use_count = remaining_use_count - 1 WHERE code = ? AND remaining_use_count > 0", nil, code)
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected > 0, nil
+}
+
 func (s *Server) getRepoActorByDid(ctx context.Context, did string) (*models.RepoActor, error) {
 	var repo models.RepoActor
 	if err := s.db.Raw(ctx, "SELECT r.*, a.* FROM repos r LEFT JOIN actors a ON r.did = a.did WHERE r.did = ?", nil, did).Scan(&repo).Error; err != nil {

--- a/server/handle_server_create_account.go
+++ b/server/handle_server_create_account.go
@@ -108,23 +108,8 @@ func (s *Server) handleCreateAccount(e echo.Context) error {
 		return helpers.InputError(e, to.StringPtr("HandleNotAvailable"))
 	}
 
-	var ic models.InviteCode
-	if s.config.RequireInvite {
-		if strings.TrimSpace(request.InviteCode) == "" {
-			return helpers.InputError(e, to.StringPtr("InvalidInviteCode"))
-		}
-
-		if err := s.db.Raw(ctx, "SELECT * FROM invite_codes WHERE code = ?", nil, request.InviteCode).Scan(&ic).Error; err != nil {
-			if err == gorm.ErrRecordNotFound {
-				return helpers.InputError(e, to.StringPtr("InvalidInviteCode"))
-			}
-			logger.Error("error getting invite code from db", "error", err)
-			return helpers.ServerError(e, nil)
-		}
-
-		if ic.RemainingUseCount < 1 {
-			return helpers.InputError(e, to.StringPtr("InvalidInviteCode"))
-		}
+	if s.config.RequireInvite && strings.TrimSpace(request.InviteCode) == "" {
+		return helpers.InputError(e, to.StringPtr("InvalidInviteCode"))
 	}
 
 	// see if the email is already taken
@@ -135,6 +120,20 @@ func (s *Server) handleCreateAccount(e echo.Context) error {
 	}
 	if err == nil && existingRepo.Did != signupDid {
 		return helpers.InputError(e, to.StringPtr("EmailNotAvailable"))
+	}
+
+	// Claim one invite use atomically before any account creation so that
+	// concurrent signups cannot exceed a code's remaining uses. Done after the
+	// handle/email availability checks so those failures don't burn a use.
+	if s.config.RequireInvite {
+		consumed, err := s.consumeInviteCode(ctx, request.InviteCode)
+		if err != nil {
+			logger.Error("error consuming invite code", "error", err)
+			return helpers.ServerError(e, nil)
+		}
+		if !consumed {
+			return helpers.InputError(e, to.StringPtr("InvalidInviteCode"))
+		}
 	}
 
 	// TODO: unsupported domains
@@ -250,13 +249,6 @@ func (s *Server) handleCreateAccount(e echo.Context) error {
 				Time:   time.Now().Format(util.ISO8601),
 			},
 		})
-	}
-
-	if s.config.RequireInvite {
-		if err := s.db.Raw(ctx, "UPDATE invite_codes SET remaining_use_count = remaining_use_count - 1 WHERE code = ?", nil, request.InviteCode).Scan(&ic).Error; err != nil {
-			logger.Error("error decrementing use count", "error", err)
-			return helpers.ServerError(e, nil)
-		}
 	}
 
 	sess, err := s.createSession(ctx, &urepo)

--- a/server/invite_code_test.go
+++ b/server/invite_code_test.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/haileyok/cocoon/models"
+)
+
+func (s *Server) insertInviteCode(t *testing.T, code string, uses int) {
+	t.Helper()
+	if err := s.db.Create(context.Background(), &models.InviteCode{
+		Code:              code,
+		RemainingUseCount: uses,
+	}, nil).Error; err != nil {
+		t.Fatalf("insert invite code: %v", err)
+	}
+}
+
+func (s *Server) inviteRemaining(t *testing.T, code string) int {
+	t.Helper()
+	var ic models.InviteCode
+	if err := s.db.Raw(context.Background(), "SELECT * FROM invite_codes WHERE code = ?", nil, code).Scan(&ic).Error; err != nil {
+		t.Fatalf("read invite code: %v", err)
+	}
+	return ic.RemainingUseCount
+}
+
+func TestConsumeInviteCode(t *testing.T) {
+	ctx := context.Background()
+	s := newTestServer(t)
+	s.insertInviteCode(t, "single-use", 1)
+
+	ok, err := s.consumeInviteCode(ctx, "single-use")
+	if err != nil {
+		t.Fatalf("consume: %v", err)
+	}
+	if !ok {
+		t.Fatal("first consume should succeed")
+	}
+	if got := s.inviteRemaining(t, "single-use"); got != 0 {
+		t.Fatalf("remaining = %d, want 0", got)
+	}
+
+	ok, err = s.consumeInviteCode(ctx, "single-use")
+	if err != nil {
+		t.Fatalf("consume (exhausted): %v", err)
+	}
+	if ok {
+		t.Fatal("second consume should fail once exhausted")
+	}
+	if got := s.inviteRemaining(t, "single-use"); got != 0 {
+		t.Fatalf("remaining went to %d; must never drop below 0", got)
+	}
+
+	ok, err = s.consumeInviteCode(ctx, "does-not-exist")
+	if err != nil {
+		t.Fatalf("consume (missing): %v", err)
+	}
+	if ok {
+		t.Fatal("consuming a nonexistent code should fail")
+	}
+}
+
+// TestConsumeInviteCodeConcurrent proves the consume is atomic: with a 1-use
+// code and many concurrent callers, exactly one wins and the count never goes
+// negative. A naive "remaining_use_count - 1" would let every caller succeed.
+func TestConsumeInviteCodeConcurrent(t *testing.T) {
+	ctx := context.Background()
+	s := newTestServer(t)
+
+	// Serialize at the connection level so the test exercises the conditional
+	// UPDATE's correctness rather than SQLite write-lock contention.
+	if sqlDB, err := s.db.Client().DB(); err == nil {
+		sqlDB.SetMaxOpenConns(1)
+	} else {
+		t.Fatalf("get sql db: %v", err)
+	}
+
+	const uses = 1
+	const goroutines = 25
+	s.insertInviteCode(t, "race", uses)
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	successes := 0
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			ok, err := s.consumeInviteCode(ctx, "race")
+			if err != nil {
+				t.Errorf("consume: %v", err)
+				return
+			}
+			if ok {
+				mu.Lock()
+				successes++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if successes != uses {
+		t.Fatalf("successful consumes = %d, want %d", successes, uses)
+	}
+	if got := s.inviteRemaining(t, "race"); got != 0 {
+		t.Fatalf("remaining = %d, want 0 (must never go negative)", got)
+	}
+}


### PR DESCRIPTION
## Bug (High)

`handleCreateAccount` checked an invite code's `remaining_use_count` up front (`SELECT ... ; if < 1 reject`) and decremented it only at the very end, after the PLC op and DB writes — with no transaction or row lock between check and decrement. Concurrent signups using one single-use code could all pass the check and create accounts, and the blind `remaining_use_count - 1` could drive the count negative. This defeats `RequireInvite`, the main account-creation gate.

## Fix

Add `consumeInviteCode` (`server/common.go`): a single atomic conditional update

```sql
UPDATE invite_codes SET remaining_use_count = remaining_use_count - 1
WHERE code = ? AND remaining_use_count > 0
```

and treat `RowsAffected > 0` as success. `handleCreateAccount` now claims one use via this helper **before** any account creation (so the slot is reserved atomically) but **after** the handle/email availability checks (so those common failures don't burn a use). The old up-front read-check and the late non-atomic decrement are removed.

### Tradeoff

A use is now claimed before the PLC op / DB inserts, so a *rare infrastructure failure* during creation consumes a use (no refund). This is the price of atomic gating without wrapping a network PLC call in a DB transaction; common user-facing validation errors (handle/email taken, missing code) still happen before any consumption.

## Tests

- `TestConsumeInviteCode` — single use succeeds then exhausts; nonexistent code fails; count never goes below 0.
- `TestConsumeInviteCodeConcurrent` — 25 goroutines race for a 1-use code; exactly one wins and the count lands at 0 (a naive decrement would let all 25 "succeed" and go negative). Runs under `-race`.

## Verification

`gofmt` clean, `go vet ./server/` clean, `go test -race ./server/` passes.