### PR TITLE
fix: guard nil DPoP values in oauth refresh grant

### DIFF
--- a/server/handle_oauth_token.go
+++ b/server/handle_oauth_token.go
@@ -215,7 +215,7 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 			return helpers.InputError(e, to.StringPtr(`"client authentication method mismatch`))
 		}
 
-		if *oauthToken.Parameters.DpopJkt != proof.JKT {
+		if !dpopJktMatches(oauthToken.Parameters.DpopJkt, proof) {
 			return helpers.InputError(e, to.StringPtr("dpop proof does not match expected jkt"))
 		}
 
@@ -282,4 +282,15 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 	}
 
 	return helpers.InputError(e, to.StringPtr(fmt.Sprintf(`grant type "%s" is not supported`, req.GrantType)))
+}
+
+// dpopJktMatches reports whether a stored token's DPoP confirmation key is
+// satisfied by the presented proof. A token that is not DPoP-bound (tokenJkt
+// nil) is not constrained here; a DPoP-bound token requires a proof whose JKT
+// matches. Both operands are nilable, so callers must not dereference directly.
+func dpopJktMatches(tokenJkt *string, proof *dpop.Proof) bool {
+	if tokenJkt == nil {
+		return true
+	}
+	return proof != nil && *tokenJkt == proof.JKT
 }

--- a/server/oauth_token_dpop_test.go
+++ b/server/oauth_token_dpop_test.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/haileyok/cocoon/oauth/dpop"
+)
+
+func TestDpopJktMatches(t *testing.T) {
+	jkt := "thumbprint-abc"
+	other := jkt
+
+	tests := []struct {
+		name     string
+		tokenJkt *string
+		proof    *dpop.Proof
+		want     bool
+	}{
+		{"not bound, no proof", nil, nil, true},
+		{"not bound, proof present", nil, &dpop.Proof{JKT: jkt}, true},
+		{"bound, missing proof", &jkt, nil, false},
+		{"bound, matching proof", &jkt, &dpop.Proof{JKT: other}, true},
+		{"bound, mismatched proof", &jkt, &dpop.Proof{JKT: "different"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dpopJktMatches(tt.tokenJkt, tt.proof); got != tt.want {
+				t.Fatalf("dpopJktMatches = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug (Medium)

In the `refresh_token` grant (`server/handle_oauth_token.go`), the DPoP binding check dereferenced two nilable values with no guards:

```go
if *oauthToken.Parameters.DpopJkt != proof.JKT { ... }
```

- `oauthToken.Parameters.DpopJkt` is `nil` for non-DPoP-bound tokens (the code even handles `DpopJkt == nil` a few lines later).
- `proof` is `nil` when no DPoP header is presented (`AllowMissingDpopProof: true`).

Either case panics, aborting the refresh. Reaching it requires a valid refresh token whose `client_id` matches the authenticated caller, so it's a per-request panic / refresh breakage for non-DPoP clients rather than an auth bypass — but it's a guaranteed crash on a core auth path. (No `recover` middleware exists, so net/http drops the connection; the process survives.)

## Fix

Extract `dpopJktMatches(tokenJkt *string, proof *dpop.Proof) bool`:
- token not DPoP-bound (`tokenJkt == nil`) → unconstrained here (the existing `DpopBoundAccessTokens && DpopJkt == nil` check still applies below);
- DPoP-bound token → requires a non-nil proof whose `JKT` matches.

## Tests

`TestDpopJktMatches` table test: not-bound (with/without proof), bound+missing-proof (the former panic case), bound+matching, bound+mismatched.

## Verification

`gofmt` clean, `go vet ./server/` clean, `go test ./server/` passes.