### PR TITLE
fix: return when oauth authorization_code actor lookup fails

### DIFF
--- a/server/handle_oauth_token.go
+++ b/server/handle_oauth_token.go
@@ -133,7 +133,7 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 
 		repo, err := s.getRepoActorByDid(ctx, *authReq.Sub)
 		if err != nil {
-			helpers.InputError(e, to.StringPtr("unable to find actor"))
+			return helpers.InputError(e, to.StringPtr("unable to find actor"))
 		}
 
 		now := time.Now()

--- a/server/oauth_token_authcode_test.go
+++ b/server/oauth_token_authcode_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/haileyok/cocoon/oauth/client"
+	"github.com/haileyok/cocoon/oauth/dpop"
+	"github.com/haileyok/cocoon/oauth/provider"
+)
+
+func attachOauthProvider(t *testing.T, s *Server) {
+	t.Helper()
+	s.oauthProvider = provider.NewProvider(provider.Args{
+		Hostname: testHostname,
+		ClientManagerArgs: client.ManagerArgs{
+			Cli:    http.DefaultClient,
+			Logger: s.logger,
+		},
+		DpopManagerArgs: dpop.ManagerArgs{
+			NonceSecret:           []byte("test-nonce-secret"),
+			NonceRotationInterval: time.Hour,
+			Logger:                s.logger,
+			Hostname:              testHostname,
+		},
+	})
+}
+
+// TestOauthTokenAuthorizationCodeMissingActor drives the authorization_code
+// grant with an authorization request whose subject has no repo (e.g. the
+// account was deleted between consent and token exchange). The handler must
+// return an error response, not dereference a nil repo and panic.
+func TestOauthTokenAuthorizationCodeMissingActor(t *testing.T) {
+	ctx := context.Background()
+	s := newTestServer(t)
+	attachOauthProvider(t, s)
+
+	const (
+		clientID    = "http://localhost"
+		redirectURI = "http://127.0.0.1/"
+		code        = "test-auth-code"
+	)
+
+	authReq := provider.OauthAuthorizationRequest{
+		RequestId: "req-1",
+		ClientId:  clientID,
+		Parameters: provider.ParRequest{
+			AuthenticateClientRequestBase: provider.AuthenticateClientRequestBase{ClientID: clientID},
+			ResponseType:                  "code",
+			RedirectURI:                   redirectURI,
+			State:                         "state-1",
+			Scope:                         "atproto",
+		},
+		ExpiresAt: time.Now().Add(time.Hour),
+		Sub:       to.StringPtr("did:plc:doesnotexistxxxxxxxxxxxx"),
+		Code:      to.StringPtr(code),
+	}
+	if err := s.db.Create(ctx, &authReq, nil).Error; err != nil {
+		t.Fatalf("seed authorization request: %v", err)
+	}
+
+	form := url.Values{
+		"grant_type":   {"authorization_code"},
+		"client_id":    {clientID},
+		"code":         {code},
+		"redirect_uri": {redirectURI},
+	}
+	c, rec := newRequestContext(http.MethodPost, "/oauth/token", form.Encode(), map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	})
+
+	// Must not panic, and must surface an error response (not a token).
+	if err := s.handleOauthToken(c); err != nil {
+		c.Error(err)
+	}
+	if rec.Code/100 == 2 {
+		t.Fatalf("expected an error response for a missing actor, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Bug (Low)

In the `authorization_code` grant (`server/handle_oauth_token.go`), the actor lookup discarded its error:

```go
repo, err := s.getRepoActorByDid(ctx, *authReq.Sub)
if err != nil {
    helpers.InputError(e, to.StringPtr("unable to find actor")) // not returned
}
```

Execution fell through and dereferenced the nil `repo` (`repo.Repo.Did`), panicking the request. It's reachable when the subject account no longer exists at token-exchange time (deleted between consent and exchange) or on a transient DB error. Robustness/DoS, not an auth bypass; with no `recover` middleware, net/http drops the single connection.

## Fix

`return` the `InputError` response.

## Test

`TestOauthTokenAuthorizationCodeMissingActor` drives the full grant via a loopback (`http://localhost`, auth method `none`, no network) client and a seeded authorization request whose `sub` has no repo. Confirmed it **panics at line 148 without the fix** and returns a 400 with it. Adds reusable `attachOauthProvider` test helper.

## Verification

`gofmt` clean, `go vet ./server/` clean, `go test ./server/` passes.