### PR TITLE
fix: compare PKCE code_verifier by value, not pointer

### DIFF
--- a/server/handle_oauth_token.go
+++ b/server/handle_oauth_token.go
@@ -105,27 +105,8 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 				return helpers.InputError(e, to.StringPtr(`"code_verifier" is too short`))
 			}
 
-			switch *&authReq.Parameters.CodeChallengeMethod {
-			case "", "plain":
-				if authReq.Parameters.CodeChallenge != req.CodeVerifier {
-					return helpers.InputError(e, to.StringPtr("invalid code_verifier"))
-				}
-			case "S256":
-				inputChal, err := base64.RawURLEncoding.DecodeString(*authReq.Parameters.CodeChallenge)
-				if err != nil {
-					logger.Error("error decoding code challenge", "error", err)
-					return helpers.ServerError(e, nil)
-				}
-
-				h := sha256.New()
-				h.Write([]byte(*req.CodeVerifier))
-				compdChal := h.Sum(nil)
-
-				if !bytes.Equal(inputChal, compdChal) {
-					return helpers.InputError(e, to.StringPtr("invalid code_verifier"))
-				}
-			default:
-				return helpers.InputError(e, to.StringPtr("unsupported code_challenge_method "+*&authReq.Parameters.CodeChallengeMethod))
+			if err := verifyPKCE(*authReq.Parameters.CodeChallenge, authReq.Parameters.CodeChallengeMethod, *req.CodeVerifier); err != nil {
+				return helpers.InputError(e, to.StringPtr(err.Error()))
 			}
 		} else if req.CodeVerifier != nil {
 			return helpers.InputError(e, to.StringPtr("code_challenge parameter wasn't provided"))
@@ -282,4 +263,28 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 	}
 
 	return helpers.InputError(e, to.StringPtr(fmt.Sprintf(`grant type "%s" is not supported`, req.GrantType)))
+}
+
+// verifyPKCE checks a PKCE code_verifier against the stored code_challenge for
+// the given method, comparing values (not pointers). Returns a non-nil error
+// describing the failure, or nil when the verifier satisfies the challenge.
+func verifyPKCE(challenge, method, verifier string) error {
+	switch method {
+	case "", "plain":
+		if challenge != verifier {
+			return errors.New("invalid code_verifier")
+		}
+	case "S256":
+		expected, err := base64.RawURLEncoding.DecodeString(challenge)
+		if err != nil {
+			return fmt.Errorf("invalid code_challenge: %w", err)
+		}
+		sum := sha256.Sum256([]byte(verifier))
+		if !bytes.Equal(expected, sum[:]) {
+			return errors.New("invalid code_verifier")
+		}
+	default:
+		return fmt.Errorf("unsupported code_challenge_method %s", method)
+	}
+	return nil
 }

--- a/server/pkce_test.go
+++ b/server/pkce_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestVerifyPKCE(t *testing.T) {
+	verifier := strings.Repeat("a", 43)
+	s256Challenge := func(v string) string {
+		sum := sha256.Sum256([]byte(v))
+		return base64.RawURLEncoding.EncodeToString(sum[:])
+	}
+
+	tests := []struct {
+		name      string
+		challenge string
+		method    string
+		verifier  string
+		wantErr   bool
+	}{
+		// Equal but distinct string values: the old pointer comparison treated
+		// these as unequal; a value comparison must accept them.
+		{"plain match", "a-shared-secret-verifier", "plain", "a-shared-secret-verifier", false},
+		{"empty method match", "a-shared-secret-verifier", "", "a-shared-secret-verifier", false},
+		{"plain mismatch", "challenge-value", "plain", "different-value", true},
+		{"s256 match", s256Challenge(verifier), "S256", verifier, false},
+		{"s256 mismatch", s256Challenge(verifier), "S256", "wrong-verifier", true},
+		{"unsupported method", "x", "S512", "y", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyPKCE(tt.challenge, tt.method, tt.verifier)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("verifyPKCE(%q, %q, %q) err = %v, wantErr = %v", tt.challenge, tt.method, tt.verifier, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug (Low)

In the `authorization_code` grant (`server/handle_oauth_token.go`), the PKCE "plain" branch compared two `*string` **pointers**:

```go
if authReq.Parameters.CodeChallenge != req.CodeVerifier { ... }
```

`CodeChallenge` (from the DB scan) and `CodeVerifier` (from the form bind) are always distinct allocations, so `!=` was always true and every `plain`/empty-method PKCE exchange was wrongly rejected. This is **fail-closed** (a functional break for plain-PKCE clients), not an auth bypass — the S256 path was already correct.

## Fix

Extract `verifyPKCE(challenge, method, verifier string) error` that compares dereferenced **values** for `plain`/`""` and keeps the existing S256 hash comparison. The handler calls it and surfaces any error as an `InputError`. Also removes the no-op `*&` expressions.

Minor behavior change: a malformed *stored* S256 challenge (base64 decode failure) now yields a 400 instead of a 500; this is server-side data that shouldn't occur in practice.

## Test

`TestVerifyPKCE` table test, including equal-but-distinct strings for `plain`/`""` (the exact case the pointer compare got wrong), S256 match/mismatch, and an unsupported method.

## Verification

`gofmt` clean, `go vet ./server/` clean, `go test ./server/` passes.