### PR TITLE
fix: invalidate 2FA codes after use and compare in constant time

### DIFF
--- a/server/handle_account_signin.go
+++ b/server/handle_account_signin.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"strings"
@@ -193,12 +194,17 @@ func (s *Server) handleAccountSigninPost(e echo.Context) error {
 			return e.Redirect(303, "/account/signin"+queryParams)
 		}
 
-		if *repo.TwoFactorCode != req.AuthFactorToken {
+		if subtle.ConstantTimeCompare([]byte(*repo.TwoFactorCode), []byte(req.AuthFactorToken)) != 1 {
 			return helpers.InvalidTokenError(e)
 		}
 
 		if time.Now().UTC().After(*repo.TwoFactorCodeExpiresAt) {
 			return helpers.ExpiredTokenError(e)
+		}
+
+		if err := s.clearTwoFactorCode(ctx, repo.Repo.Did); err != nil {
+			logger.Error("error clearing 2FA code", "error", err)
+			return helpers.ServerError(e, nil)
 		}
 	}
 

--- a/server/handle_server_create_session.go
+++ b/server/handle_server_create_session.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"strings"
@@ -117,12 +118,17 @@ func (s *Server) handleCreateSession(e echo.Context) error {
 			return helpers.InputError(e, to.StringPtr("AuthFactorTokenRequired"))
 		}
 
-		if *repo.TwoFactorCode != *req.AuthFactorToken {
+		if subtle.ConstantTimeCompare([]byte(*repo.TwoFactorCode), []byte(*req.AuthFactorToken)) != 1 {
 			return helpers.InvalidTokenError(e)
 		}
 
 		if time.Now().UTC().After(*repo.TwoFactorCodeExpiresAt) {
 			return helpers.ExpiredTokenError(e)
+		}
+
+		if err := s.clearTwoFactorCode(ctx, repo.Repo.Did); err != nil {
+			logger.Error("error clearing 2FA code", "error", err)
+			return helpers.ServerError(e, nil)
 		}
 	}
 
@@ -143,6 +149,10 @@ func (s *Server) handleCreateSession(e echo.Context) error {
 		Active:          repo.Active(),
 		Status:          repo.Status(),
 	})
+}
+
+func (s *Server) clearTwoFactorCode(ctx context.Context, did string) error {
+	return s.db.Exec(ctx, "UPDATE repos SET two_factor_code = NULL, two_factor_code_expires_at = NULL WHERE did = ?", nil, did).Error
 }
 
 func (s *Server) createAndSendTwoFactorCode(ctx context.Context, repo models.RepoActor) error {

--- a/server/two_factor_test.go
+++ b/server/two_factor_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/haileyok/cocoon/models"
+)
+
+func (s *Server) setTwoFactor(t *testing.T, did, code string, expiresAt time.Time) {
+	t.Helper()
+	if err := s.db.Exec(context.Background(),
+		"UPDATE repos SET two_factor_type = ?, two_factor_code = ?, two_factor_code_expires_at = ? WHERE did = ?",
+		nil, models.TwoFactorTypeEmail, code, expiresAt, did,
+	).Error; err != nil {
+		t.Fatalf("set two factor: %v", err)
+	}
+}
+
+func (s *Server) twoFactorCode(t *testing.T, did string) *string {
+	t.Helper()
+	var repo models.Repo
+	if err := s.db.Raw(context.Background(), "SELECT * FROM repos WHERE did = ?", nil, did).Scan(&repo).Error; err != nil {
+		t.Fatalf("read repo: %v", err)
+	}
+	return repo.TwoFactorCode
+}
+
+func TestCreateSessionTwoFactorClearedOnSuccess(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	const code = "ABCDE-FGHIJ"
+	s.setTwoFactor(t, acct.Did, code, time.Now().Add(10*time.Minute))
+
+	body := fmt.Sprintf(`{"identifier":%q,"password":%q,"authFactorToken":%q}`, acct.Handle, acct.Password, code)
+	c, rec := newRequestContext(http.MethodPost, "/xrpc/com.atproto.server.createSession", body, nil)
+
+	if err := s.handleCreateSession(c); err != nil {
+		c.Error(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 with a valid 2FA code, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := s.twoFactorCode(t, acct.Did); got != nil {
+		t.Fatalf("two_factor_code should be cleared after a successful login, still set to %q", *got)
+	}
+}
+
+func TestCreateSessionTwoFactorWrongCode(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "bob.pds.test")
+	const code = "ABCDE-FGHIJ"
+	s.setTwoFactor(t, acct.Did, code, time.Now().Add(10*time.Minute))
+
+	body := fmt.Sprintf(`{"identifier":%q,"password":%q,"authFactorToken":%q}`, acct.Handle, acct.Password, "WRONG-CODES")
+	c, rec := newRequestContext(http.MethodPost, "/xrpc/com.atproto.server.createSession", body, nil)
+
+	if err := s.handleCreateSession(c); err != nil {
+		c.Error(err)
+	}
+	if rec.Code == http.StatusOK {
+		t.Fatalf("expected rejection for a wrong 2FA code, got 200")
+	}
+	if got := s.twoFactorCode(t, acct.Did); got == nil || *got != code {
+		t.Fatalf("two_factor_code must remain set after a failed attempt, got %v", got)
+	}
+}


### PR DESCRIPTION
## Bug (Low / defense-in-depth)

Email 2FA codes (`com.atproto.server.createSession` and the web signin flow) were:
- **never cleared after a successful login**, so a code stayed valid and replayable for its full 10-minute window and across multiple logins; and
- compared with a plain `!=` string comparison (not constant-time).

(Brute force isn't practical — codes are 2^50 entropy — so this is a hardening fix, not an account-takeover path.)

## Fix

- Add `clearTwoFactorCode(ctx, did)` and call it once a code is accepted (after the match + expiry checks) in both `handleCreateSession` and `handleAccountSigninPost`, so a code is single-use.
- Replace the equality checks with `subtle.ConstantTimeCompare`.

Failed attempts leave the code in place (so a typo doesn't force a new code); expired codes are overwritten on the next request as before.

## Tests

`TestCreateSessionTwoFactorClearedOnSuccess` (valid code → 200 and `two_factor_code` is `NULL`) and `TestCreateSessionTwoFactorWrongCode` (wrong code → rejected, code preserved). The "cleared on success" assertion was red before the fix.

## Verification

`gofmt` clean, `go vet ./server/` clean, `go test ./server/` passes.