### PR TITLE
fix: set Secure on the session cookie outside dev

### DIFF
--- a/server/handle_account_signin.go
+++ b/server/handle_account_signin.go
@@ -46,7 +46,7 @@ func (s *Server) getSessionRepoAndAccountsFromSessionOrErr(e echo.Context, ctx c
 		return nil, sess, nil, err
 	}
 	if changed {
-		applyAccountSessionOptions(sess, int(AccountSessionMaxAge.Seconds()))
+		s.applyAccountSessionOptions(sess, int(AccountSessionMaxAge.Seconds()))
 		if err := sess.Save(e.Request(), e.Response()); err != nil {
 			return nil, sess, nil, err
 		}
@@ -202,7 +202,7 @@ func (s *Server) handleAccountSigninPost(e echo.Context) error {
 		}
 	}
 
-	applyAccountSessionOptions(sess, int(AccountSessionMaxAge.Seconds()))
+	s.applyAccountSessionOptions(sess, int(AccountSessionMaxAge.Seconds()))
 
 	setActiveSessionDid(sess, repo.Repo.Did)
 

--- a/server/handle_account_signout.go
+++ b/server/handle_account_signout.go
@@ -21,7 +21,7 @@ func (s *Server) handleAccountSignout(e echo.Context) error {
 		maxAge = -1
 	}
 
-	applyAccountSessionOptions(sess, maxAge)
+	s.applyAccountSessionOptions(sess, maxAge)
 
 	if err := sess.Save(e.Request(), e.Response()); err != nil {
 		return err

--- a/server/handle_account_switch.go
+++ b/server/handle_account_switch.go
@@ -100,7 +100,7 @@ func (s *Server) handleAccountSwitchPost(e echo.Context) error {
 	}
 
 	setActiveSessionDid(sess, req.Did)
-	applyAccountSessionOptions(sess, int(AccountSessionMaxAge.Seconds()))
+	s.applyAccountSessionOptions(sess, int(AccountSessionMaxAge.Seconds()))
 
 	if err := sess.Save(e.Request(), e.Response()); err != nil {
 		return err

--- a/server/handle_oauth_authorize.go
+++ b/server/handle_oauth_authorize.go
@@ -128,7 +128,7 @@ func (s *Server) handleOauthAuthorizeGet(e echo.Context) error {
 		}
 
 		setActiveSessionDid(sess, did)
-		applyAccountSessionOptions(sess, int(AccountSessionMaxAge.Seconds()))
+		s.applyAccountSessionOptions(sess, int(AccountSessionMaxAge.Seconds()))
 		if err := sess.Save(e.Request(), e.Response()); err != nil {
 			return helpers.ServerError(e, to.StringPtr(err.Error()))
 		}

--- a/server/session_options.go
+++ b/server/session_options.go
@@ -6,11 +6,12 @@ import (
 	"github.com/gorilla/sessions"
 )
 
-func applyAccountSessionOptions(sess *sessions.Session, maxAge int) {
+func (s *Server) applyAccountSessionOptions(sess *sessions.Session, maxAge int) {
 	sess.Options = &sessions.Options{
 		Path:     "/",
 		MaxAge:   maxAge,
 		HttpOnly: true,
+		Secure:   s.config.Version != "dev",
 		SameSite: http.SameSiteLaxMode,
 	}
 }

--- a/server/session_options_test.go
+++ b/server/session_options_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/sessions"
+)
+
+func TestApplyAccountSessionOptions(t *testing.T) {
+	s := newTestServer(t) // Version "test" -> non-dev
+
+	sess := &sessions.Session{}
+	s.applyAccountSessionOptions(sess, 3600)
+
+	if sess.Options == nil {
+		t.Fatal("options were not set")
+	}
+	if !sess.Options.Secure {
+		t.Fatal("Secure must be set for non-dev builds")
+	}
+	if !sess.Options.HttpOnly {
+		t.Fatal("HttpOnly must remain set")
+	}
+	if sess.Options.SameSite != http.SameSiteLaxMode {
+		t.Fatalf("SameSite = %v, want Lax", sess.Options.SameSite)
+	}
+	if sess.Options.MaxAge != 3600 {
+		t.Fatalf("MaxAge = %d, want 3600", sess.Options.MaxAge)
+	}
+
+	// Plain local dev (default Version "dev") serves over http, so Secure must
+	// stay off there or the cookie would never be sent.
+	s.config.Version = "dev"
+	devSess := &sessions.Session{}
+	s.applyAccountSessionOptions(devSess, 3600)
+	if devSess.Options.Secure {
+		t.Fatal("Secure must be off in dev mode")
+	}
+}


### PR DESCRIPTION
## Bug (Low / hardening)

The account + OAuth web session cookie was set `HttpOnly` + `SameSite=Lax` but **not `Secure`** (`server/session_options.go`), so it could be transmitted over plain HTTP (cleartext exposure / MITM before HSTS). `HttpOnly` and `SameSite=Lax` were already correct, and the consent POST isn't practically CSRF-able under Lax — so this is defense-in-depth.

## Fix

`applyAccountSessionOptions` becomes a `*Server` method and sets:

```go
Secure: s.config.Version != "dev",
```

- All built/deployed binaries (`make build`, Docker, tagged releases, `make run`'s `dev-local`) → `Secure` on.
- The default-`Version` local `go run` (`Version == "dev"`) → `Secure` off, so local http login still works.

The 5 call sites are updated to the method form. (Per discussion: gated on `Version != "dev"` rather than unconditional, to avoid breaking plain-http local dev; happy to switch to an explicit insecure-cookies config flag if you'd prefer that knob instead.)

## Test

`TestApplyAccountSessionOptions`: non-dev sets `Secure` (and preserves `HttpOnly`/`Lax`/`MaxAge`); `Version=="dev"` leaves `Secure` off.

## Verification

`gofmt` clean, `go vet ./server/` clean, `go test ./server/` passes.