### PR TITLE
fix: generate security codes with crypto/rand

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -4,7 +4,6 @@ import (
 	crand "crypto/rand"
 	"encoding/hex"
 	"errors"
-	"math/rand"
 	"net/url"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -67,9 +66,15 @@ func genericError(e echo.Context, code int, msg string) error {
 }
 
 func RandomVarchar(length int) string {
+	// letters has 32 entries, which divides 256 evenly, so a byte mod len(letters)
+	// is an unbiased index into the alphabet.
+	raw := make([]byte, length)
+	if _, err := crand.Read(raw); err != nil {
+		panic(err)
+	}
 	b := make([]rune, length)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+	for i, v := range raw {
+		b[i] = letters[int(v)%len(letters)]
 	}
 	return string(b)
 }

--- a/internal/helpers/helpers_test.go
+++ b/internal/helpers/helpers_test.go
@@ -1,0 +1,27 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRandomVarchar(t *testing.T) {
+	const allowed = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+	for _, n := range []int{1, 5, 6, 24, 64} {
+		got := RandomVarchar(n)
+		if len(got) != n {
+			t.Fatalf("RandomVarchar(%d) length = %d", n, len(got))
+		}
+		for _, r := range got {
+			if !strings.ContainsRune(allowed, r) {
+				t.Fatalf("RandomVarchar(%d) produced %q outside the allowed alphabet", n, r)
+			}
+		}
+	}
+
+	// Two independent 24-char draws colliding would indicate a broken generator.
+	if RandomVarchar(24) == RandomVarchar(24) {
+		t.Fatal("two 24-char codes were identical")
+	}
+}


### PR DESCRIPTION
## Bug (cross-cutting hardening)

`helpers.RandomVarchar` used `math/rand`, but it generates security-sensitive codes:
- email 2FA codes (`createAndSendTwoFactorCode`)
- password-reset codes (`requestPasswordReset`)
- account-delete codes
- email verification codes (`createAccount`)
- invite codes

`math/rand` is not a CSPRNG; its output can be predictable to an attacker who observes prior values. These codes should be unpredictable.

## Fix

Switch `RandomVarchar` to `crypto/rand`. The alphabet (`A-Z2-7`, 32 chars) divides 256 evenly, so `byte % len(letters)` is an unbiased index — the output charset/length (and the `^[A-Z2-7]{5}-[A-Z2-7]{5}$` code shape) are unchanged. `crypto/rand.Read` is treated as infallible (panics on the impossible RNG failure, fail-closed). The now-unused `math/rand` import is removed.

## Test

`TestRandomVarchar` (contract guard): correct length, every char within the allowed alphabet, and two 24-char draws differ.

> Note: a CSPRNG's output is indistinguishable from a PRNG's in a unit test, so there's no behavioral red/green here — the test guards the conversion's correctness (charset/length) and the security property is the `crypto/rand` change itself.

## Verification

`gofmt` clean, `go vet ./...` clean, `go test -race ./...` passes.