### PR TITLE
style: gofmt handle_oauth_token.go

### DIFF
--- a/server/handle_oauth_token.go
+++ b/server/handle_oauth_token.go
@@ -286,7 +286,7 @@ func verifyPKCE(challenge, method, verifier string) error {
 	default:
 		return fmt.Errorf("unsupported code_challenge_method %s", method)
 	}
-  return nil
+	return nil
 }
 
 // dpopJktMatches reports whether a stored token's DPoP confirmation key is


### PR DESCRIPTION
## What

`server/handle_oauth_token.go` is not gofmt-clean on `main`: merging the three overlapping oauth-token PRs (#96/#97/#98) left `verifyPKCE`'s final `return nil` **space-indented instead of tab-indented**. `make lint` (`test -z $(gofmt -l ./...)`) currently fails on `main` because of it. One-line `gofmt -w` fix.

## Why CI didn't catch it

`.github/workflows/go-test.yml` runs `go vet` + `go test -race` but **not** a gofmt check, so formatting regressions slip through. Happy to follow up with a tiny PR adding `gofmt -l` (fail if non-empty) to the workflow so this can't recur — say the word.

## Verification

`gofmt -l` clean across the tree, `go vet ./...` clean, `go build ./...` ok.