### PR TITLE
fix: getLatestCommit returns cid field per lexicon

### DIFF
--- a/server/handle_sync_get_latest_commit.go
+++ b/server/handle_sync_get_latest_commit.go
@@ -7,7 +7,7 @@ import (
 )
 
 type ComAtprotoSyncGetLatestCommitResponse struct {
-	Cid string `json:"string"`
+	Cid string `json:"cid"`
 	Rev string `json:"rev"`
 }
 

--- a/server/handle_sync_get_latest_commit_test.go
+++ b/server/handle_sync_get_latest_commit_test.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+)
+
+// TestHandleSyncGetLatestCommitReturnsCid asserts the response body uses the
+// lexicon-required "cid" key (com.atproto.sync.getLatestCommit -> {cid, rev}).
+func TestHandleSyncGetLatestCommitReturnsCid(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+
+	pref := cid.NewPrefixV1(cid.DagCBOR, multihash.SHA2_256)
+	c, err := pref.Sum([]byte("a fake commit block"))
+	if err != nil {
+		t.Fatalf("build cid: %v", err)
+	}
+	const rev = "3laaaaaaaaa2x"
+
+	if err := s.db.Exec(context.Background(), "UPDATE repos SET root = ?, rev = ? WHERE did = ?", nil, c.Bytes(), rev, acct.Did).Error; err != nil {
+		t.Fatalf("update repo: %v", err)
+	}
+
+	e, rec := newRequestContext(http.MethodGet, "/xrpc/com.atproto.sync.getLatestCommit?did="+acct.Did, "", nil)
+
+	if err := s.handleSyncGetLatestCommit(e); err != nil {
+		t.Fatalf("handleSyncGetLatestCommit: %v", err)
+	}
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal body: %v; raw=%s", err, rec.Body.String())
+	}
+	if _, ok := body["cid"]; !ok {
+		t.Fatalf("response missing \"cid\" key; body=%s", rec.Body.String())
+	}
+	if got := body["cid"]; got != c.String() {
+		t.Fatalf("cid = %v, want %s", got, c.String())
+	}
+	if got := body["rev"]; got != rev {
+		t.Fatalf("rev = %v, want %s", got, rev)
+	}
+	if _, ok := body["string"]; ok {
+		t.Fatalf("response should not contain legacy \"string\" key; body=%s", rec.Body.String())
+	}
+}


### PR DESCRIPTION
## What

`com.atproto.sync.getLatestCommit` must return `{cid, rev}`. The response struct tagged the CID field as `` `json:"string"` ``, so the handler emitted `{"string": ..., "rev": ...}`.

This fixes two pdscheck findings against hailey.at:
- **F4** — schema validation failure (missing required `cid`).
- **F3** — verifier crash (`undefined.slice`) caused by the absent `cid`.

## Change

Single line: retag the field to `` `json:"cid"` `` in `server/handle_sync_get_latest_commit.go`.

## Test

Added `TestHandleSyncGetLatestCommitReturnsCid` (white-box `package server`): sets a repo `Root`/`Rev`, calls the handler, and asserts the body has a `cid` key matching the CID string, a matching `rev`, and no legacy `string` key. Confirmed red before the fix, green after. `go vet ./...` and `go test -race ./server/` pass.