### PR TITLE
fix: getRecord returns 400 RecordNotFound for missing record

### DIFF
--- a/server/handle_repo_get_record.go
+++ b/server/handle_repo_get_record.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/bluesky-social/indigo/atproto/atdata"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/haileyok/cocoon/internal/helpers"
 	"github.com/haileyok/cocoon/models"
 	"github.com/labstack/echo/v4"
 )
@@ -35,13 +37,18 @@ func (s *Server) handleRepoGetRecord(e echo.Context) error {
 
 	var record models.Record
 	if err := s.db.Raw(ctx, "SELECT * FROM records WHERE did = ? AND nsid = ? AND rkey = ?"+cidquery, nil, params...).Scan(&record).Error; err != nil {
-		// TODO: handle error nicely
-		return err
+		return helpers.ServerError(e, nil)
+	}
+
+	// A zero-row Scan leaves record zero-valued without an error, so an empty
+	// Did means the record is not stored on this PDS.
+	if record.Did == "" {
+		return helpers.InputError(e, to.StringPtr("RecordNotFound"))
 	}
 
 	val, err := atdata.UnmarshalCBOR(record.Value)
 	if err != nil {
-		return s.handleProxy(e) // TODO: this should be getting handled like...if we don't find it in the db. why doesn't it throw error up there?
+		return helpers.ServerError(e, nil)
 	}
 
 	return e.JSON(200, ComAtprotoRepoGetRecordResponse{

--- a/server/handle_repo_get_record_test.go
+++ b/server/handle_repo_get_record_test.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/atdata"
+	"github.com/haileyok/cocoon/models"
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+)
+
+func insertTestRecord(t *testing.T, s *Server, did, nsid, rkey string, value map[string]any) string {
+	t.Helper()
+	cbor, err := atdata.MarshalCBOR(value)
+	if err != nil {
+		t.Fatalf("marshal cbor: %v", err)
+	}
+	c, err := cid.NewPrefixV1(cid.DagCBOR, multihash.SHA2_256).Sum(cbor)
+	if err != nil {
+		t.Fatalf("build cid: %v", err)
+	}
+	rec := models.Record{
+		Did:       did,
+		CreatedAt: "2024-01-01T00:00:00Z",
+		Nsid:      nsid,
+		Rkey:      rkey,
+		Cid:       c.String(),
+		Value:     cbor,
+	}
+	if err := s.db.Create(context.Background(), &rec, nil).Error; err != nil {
+		t.Fatalf("insert record: %v", err)
+	}
+	return c.String()
+}
+
+// TestHandleRepoGetRecordFound returns the locally stored record.
+func TestHandleRepoGetRecordFound(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+
+	const nsid = "app.bsky.feed.post"
+	const rkey = "3laaaaaaaaa2x"
+	cidStr := insertTestRecord(t, s, acct.Did, nsid, rkey, map[string]any{
+		"$type": nsid,
+		"text":  "hello world",
+	})
+
+	e, rec := newRequestContext(http.MethodGet, "/xrpc/com.atproto.repo.getRecord?repo="+acct.Did+"&collection="+nsid+"&rkey="+rkey, "", nil)
+	if err := s.handleRepoGetRecord(e); err != nil {
+		t.Fatalf("handleRepoGetRecord: %v", err)
+	}
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, rec.Body.String())
+	}
+	if got, want := body["uri"], "at://"+acct.Did+"/"+nsid+"/"+rkey; got != want {
+		t.Fatalf("uri = %v, want %s", got, want)
+	}
+	if got := body["cid"]; got != cidStr {
+		t.Fatalf("cid = %v, want %s", got, cidStr)
+	}
+}
+
+// TestHandleRepoGetRecordNotFound returns 400 RecordNotFound for a missing
+// record instead of proxying upstream (which would return another record).
+func TestHandleRepoGetRecordNotFound(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+
+	const nsid = "app.bsky.feed.post"
+	insertTestRecord(t, s, acct.Did, nsid, "3laaaaaaaaa2x", map[string]any{
+		"$type": nsid,
+		"text":  "hello world",
+	})
+
+	// s.passport / proxy collaborators are nil; if the handler fell through to
+	// handleProxy it would not return a clean 400 RecordNotFound.
+	e, rec := newRequestContext(http.MethodGet, "/xrpc/com.atproto.repo.getRecord?repo="+acct.Did+"&collection="+nsid+"&rkey=doesnotexist", "", nil)
+	if err := s.handleRepoGetRecord(e); err != nil {
+		t.Fatalf("handleRepoGetRecord: %v", err)
+	}
+	if rec.Code != 400 {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, rec.Body.String())
+	}
+	if body["error"] != "RecordNotFound" {
+		t.Fatalf("error = %q, want RecordNotFound; body=%s", body["error"], rec.Body.String())
+	}
+}


### PR DESCRIPTION
## What

`com.atproto.repo.getRecord` returned **another record's data with a 200** when the requested record did not exist locally.

A zero-row gorm `Raw().Scan()` returns no error and leaves `record` zero-valued. The handler then CBOR-unmarshalled an empty `Value`, and on failure fell through to `s.handleProxy(e)` (the existing TODO acknowledged this was wrong), which fetched the record from upstream and returned 200.

Fixes pdscheck finding **F2** against hailey.at.

## Change

`server/handle_repo_get_record.go`:
- After the query, detect not-found (empty `Did`) and return `helpers.InputError(e, "RecordNotFound")` (400).
- Remove the proxy fallback for locally-missing records.
- CBOR-unmarshal failures now return a real `ServerError` (500), distinct from not-found.

## Test

`server/handle_repo_get_record_test.go`:
- `TestHandleRepoGetRecordFound` — existing rkey → 200 with correct `uri`/`cid`.
- `TestHandleRepoGetRecordNotFound` — bogus rkey → 400 `RecordNotFound`, without reaching the (nil) proxy collaborators.

Confirmed red before the fix, green after. `go vet ./...` and `go test -race ./server/` pass.