### PR TITLE
fix: getBlocks returns 400 for unparseable cids

### DIFF
--- a/server/handle_sync_get_blocks.go
+++ b/server/handle_sync_get_blocks.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/bluesky-social/indigo/carstore"
 	"github.com/haileyok/cocoon/internal/helpers"
 	"github.com/ipfs/go-cid"
@@ -30,7 +31,7 @@ func (s *Server) handleGetBlocks(e echo.Context) error {
 	for _, cs := range req.Cids {
 		c, err := cid.Cast([]byte(cs))
 		if err != nil {
-			return err
+			return helpers.InputError(e, to.StringPtr("InvalidRequest"))
 		}
 
 		cids = append(cids, c)

--- a/server/handle_sync_get_blocks_test.go
+++ b/server/handle_sync_get_blocks_test.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestHandleGetBlocksBadCid returns 400 InvalidRequest when a requested cid is
+// not a parseable CID, rather than a 500.
+func TestHandleGetBlocksBadCid(t *testing.T) {
+	s := newTestServer(t)
+
+	e, rec := newRequestContext(http.MethodGet, "/xrpc/com.atproto.sync.getBlocks?did=did:web:pds.test&cids=undefined", "", nil)
+	if err := s.handleGetBlocks(e); err != nil {
+		t.Fatalf("handleGetBlocks: %v", err)
+	}
+	if rec.Code != 400 {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, rec.Body.String())
+	}
+	if body["error"] != "InvalidRequest" {
+		t.Fatalf("error = %q, want InvalidRequest; body=%s", body["error"], rec.Body.String())
+	}
+}


### PR DESCRIPTION
## What

`com.atproto.sync.getBlocks` returned a **500** when a requested `cids` value was not a parseable CID (e.g. `cids=undefined`). `cid.Cast` failures returned the raw error, which echo renders as 500.

Fixes pdscheck finding **F5** against hailey.at.

## Change

`server/handle_sync_get_blocks.go`: on CID parse failure return `helpers.InputError(e, "InvalidRequest")` (400).

## Test

`TestHandleGetBlocksBadCid` calls the handler with `cids=undefined` and asserts a 400 `InvalidRequest` body. Parse happens before repo lookup, so no valid repo is needed. Confirmed red before the fix, green after. `go vet ./...` and `go test -race ./server/` pass.