### PR TITLE
feat: publish signing key via OAuth JWKS endpoint

### DIFF
--- a/server/handle_oauth_jwks.go
+++ b/server/handle_oauth_jwks.go
@@ -1,12 +1,53 @@
 package server
 
-import "github.com/labstack/echo/v4"
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"encoding/base64"
+
+	"github.com/labstack/echo/v4"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+)
 
 type OauthJwksResponse struct {
 	Keys []any `json:"keys"`
 }
 
-// TODO: ?
 func (s *Server) handleOauthJwks(e echo.Context) error {
-	return e.JSON(200, OauthJwksResponse{Keys: []any{}})
+	keys := []any{}
+	if s.publicJwk != nil {
+		keys = append(keys, s.publicJwk)
+	}
+	return e.JSON(200, OauthJwksResponse{Keys: keys})
+}
+
+// derivePublicJWK builds the public JWK for the server's signing key. If kid is
+// empty, the key's RFC 7638 thumbprint is used so external resource servers can
+// select the key. It returns the public JWK and the resolved kid.
+func derivePublicJWK(priv *ecdsa.PrivateKey, kid string) (jwk.Key, string, error) {
+	pub, err := jwk.FromRaw(priv.Public())
+	if err != nil {
+		return nil, "", err
+	}
+
+	if kid == "" {
+		thumb, err := pub.Thumbprint(crypto.SHA256)
+		if err != nil {
+			return nil, "", err
+		}
+		kid = base64.RawURLEncoding.EncodeToString(thumb)
+	}
+
+	if err := pub.Set(jwk.KeyIDKey, kid); err != nil {
+		return nil, "", err
+	}
+	if err := pub.Set(jwk.AlgorithmKey, jwa.ES256); err != nil {
+		return nil, "", err
+	}
+	if err := pub.Set(jwk.KeyUsageKey, "sig"); err != nil {
+		return nil, "", err
+	}
+
+	return pub, kid, nil
 }

--- a/server/handle_oauth_jwks_test.go
+++ b/server/handle_oauth_jwks_test.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestHandleOauthJwksPublishesKey asserts the JWKS endpoint serves the server's
+// public signing key (EC public JWK with kid, no private material).
+func TestHandleOauthJwksPublishesKey(t *testing.T) {
+	s := newTestServer(t)
+
+	e, rec := newRequestContext(http.MethodGet, "/oauth/jwks", "", nil)
+	if err := s.handleOauthJwks(e); err != nil {
+		t.Fatalf("handleOauthJwks: %v", err)
+	}
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v; raw=%s", err, rec.Body.String())
+	}
+	if len(body.Keys) == 0 {
+		t.Fatalf("keys is empty; body=%s", rec.Body.String())
+	}
+
+	k := body.Keys[0]
+	for _, field := range []string{"kty", "crv", "x", "y", "kid"} {
+		v, ok := k[field]
+		if !ok || v == "" {
+			t.Fatalf("public jwk missing %q; jwk=%v", field, k)
+		}
+	}
+	if k["kty"] != "EC" {
+		t.Fatalf("kty = %v, want EC", k["kty"])
+	}
+	if _, ok := k["d"]; ok {
+		t.Fatalf("public jwk must not contain private component \"d\"; jwk=%v", k)
+	}
+}

--- a/server/handle_oauth_token.go
+++ b/server/handle_oauth_token.go
@@ -138,6 +138,7 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 		}
 
 		accessToken := jwt.NewWithClaims(jwt.SigningMethodES256, accessClaims)
+		accessToken.Header["kid"] = s.publicKid
 		accessString, err := accessToken.SignedString(s.privateKey)
 		if err != nil {
 			return err
@@ -236,6 +237,7 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 		}
 
 		accessToken := jwt.NewWithClaims(jwt.SigningMethodES256, accessClaims)
+		accessToken.Header["kid"] = s.publicKid
 		accessString, err := accessToken.SignedString(s.privateKey)
 		if err != nil {
 			return err

--- a/server/server.go
+++ b/server/server.go
@@ -43,6 +43,7 @@ import (
 	echo_session "github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	slogecho "github.com/samber/slog-echo"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -75,6 +76,8 @@ type Server struct {
 	logger        *slog.Logger
 	config        *config
 	privateKey    *ecdsa.PrivateKey
+	publicJwk     jwk.Key
+	publicKid     string
 	repoman       *RepoMan
 	oauthProvider *provider.Provider
 	evtman        *events.EventManager
@@ -393,6 +396,11 @@ func New(args *Args) (*Server, error) {
 		return nil, err
 	}
 
+	publicJwk, publicKid, err := derivePublicJWK(&pkey, key.KeyID())
+	if err != nil {
+		return nil, err
+	}
+
 	oauthCli := &http.Client{
 		Timeout: 10 * time.Second,
 	}
@@ -418,6 +426,8 @@ func New(args *Args) (*Server, error) {
 		db:         dbw,
 		plcClient:  plcClient,
 		privateKey: &pkey,
+		publicJwk:  publicJwk,
+		publicKid:  publicKid,
 		config: &config{
 			LogLevel:          args.LogLevel,
 			Version:           args.Version,

--- a/server/session.go
+++ b/server/session.go
@@ -30,6 +30,7 @@ func (s *Server) createSession(ctx context.Context, repo *models.Repo) (*Session
 	}
 
 	accessToken := jwt.NewWithClaims(jwt.SigningMethodES256, accessClaims)
+	accessToken.Header["kid"] = s.publicKid
 	accessString, err := accessToken.SignedString(s.privateKey)
 	if err != nil {
 		return nil, err

--- a/server/testutil_test.go
+++ b/server/testutil_test.go
@@ -81,10 +81,17 @@ func newTestServer(t *testing.T) *Server {
 		t.Fatalf("generate signing key: %v", err)
 	}
 
+	publicJwk, publicKid, err := derivePublicJWK(pkey, "")
+	if err != nil {
+		t.Fatalf("derive public jwk: %v", err)
+	}
+
 	return &Server{
 		db:         dbw,
 		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
 		privateKey: pkey,
+		publicJwk:  publicJwk,
+		publicKid:  publicKid,
 		config: &config{
 			Version:          "test",
 			Did:              testDid,


### PR DESCRIPTION
## What

The OAuth JWKS endpoint (`/oauth/jwks`) was hardcoded to `{"keys":[]}`, and `New` discarded the parsed `jwk.Key` after extracting the ECDSA private key — so the public key and its `kid` were never exposed. External resource servers had no way to fetch the key to verify issued access tokens.

Fixes pdscheck warning **W5** against hailey.at.

## Change

- `server/handle_oauth_jwks.go`: add `derivePublicJWK` (public JWK from the signing key; preserves the source `kid`, else uses the RFC 7638 SHA-256 thumbprint, and sets `alg=ES256`, `use=sig`). The handler now serves `{keys:[publicJwk]}`.
- `server/server.go`: derive the public JWK in `New` and store `publicJwk` / `publicKid` on `Server`.
- `server/session.go` + `server/handle_oauth_token.go`: stamp the `kid` JWT header on issued access tokens (password-grant session, and both OAuth grants) so verifiers can select the key.

Internal token verification uses `s.privateKey.Public()` directly and is unaffected by the new header.

## Test

`TestHandleOauthJwksPublishesKey`: asserts the endpoint returns a non-empty `keys` array containing an EC public JWK with `kid`/`kty`/`crv`/`x`/`y` and **no** private `d`. The harness (`newTestServer`) now wires `publicJwk`/`publicKid` via the same `derivePublicJWK` helper.

Confirmed red before the fix, green after. `go vet ./...` and `go test -race ./server/` pass.

## Note

`gofmt -l` flags `server/handle_oauth_token.go` due to a **pre-existing** malformed indent on the `verifyPKCE` `return nil` line (unrelated to this change; owned by the open gofmt PR #103). I left it untouched to avoid conflicting with that PR; my added lines are gofmt-clean and CI does not run a gofmt check.