### PR TITLE
feat: firehose Sync 1.1 (prevData on #commit + #sync events)

### DIFF
--- a/server/firehose_sync_test.go
+++ b/server/firehose_sync_test.go
@@ -1,0 +1,187 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/indigo/api/atproto"
+	atp "github.com/bluesky-social/indigo/atproto/repo"
+	"github.com/bluesky-social/indigo/atproto/repo/mst"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/events"
+	"github.com/ipfs/go-cid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+func newTestEvtman(t *testing.T) *events.EventManager {
+	t.Helper()
+	gdb, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "events.db")), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open events db: %v", err)
+	}
+	p, err := NewDbPersister(gdb, time.Hour)
+	if err != nil {
+		t.Fatalf("new persister: %v", err)
+	}
+	return events.NewEventManager(p)
+}
+
+// seedGenesisRepo commits an empty repo for did and records it as the head.
+func (s *Server) seedGenesisRepo(t *testing.T, did string, signingKey []byte) (cid.Cid, string) {
+	t.Helper()
+	bs := s.getBlockstore(did)
+	clk := syntax.NewTIDClock(0)
+	r := &atp.Repo{
+		DID:         syntax.DID(did),
+		Clock:       clk,
+		MST:         mst.NewEmptyTree(),
+		RecordStore: bs,
+	}
+	root, rev, err := commitRepo(context.Background(), bs, r, signingKey)
+	if err != nil {
+		t.Fatalf("commit genesis: %v", err)
+	}
+	if err := s.UpdateRepo(context.Background(), did, root, rev); err != nil {
+		t.Fatalf("update repo: %v", err)
+	}
+	return root, rev
+}
+
+func TestSubscribeReposMsgType(t *testing.T) {
+	cases := []struct {
+		evt  *events.XRPCStreamEvent
+		want string
+	}{
+		{&events.XRPCStreamEvent{RepoCommit: &atproto.SyncSubscribeRepos_Commit{}}, "#commit"},
+		{&events.XRPCStreamEvent{RepoSync: &atproto.SyncSubscribeRepos_Sync{}}, "#sync"},
+		{&events.XRPCStreamEvent{RepoIdentity: &atproto.SyncSubscribeRepos_Identity{}}, "#identity"},
+		{&events.XRPCStreamEvent{RepoAccount: &atproto.SyncSubscribeRepos_Account{}}, "#account"},
+		{&events.XRPCStreamEvent{RepoInfo: &atproto.SyncSubscribeRepos_Info{}}, "#info"},
+	}
+	for _, c := range cases {
+		mt, obj, ok := subscribeReposMsgType(c.evt)
+		if !ok || mt != c.want {
+			t.Fatalf("subscribeReposMsgType = (%q, ok=%v), want %q", mt, ok, c.want)
+		}
+		if obj == nil {
+			t.Fatalf("obj is nil for %q", c.want)
+		}
+	}
+	if _, _, ok := subscribeReposMsgType(&events.XRPCStreamEvent{}); ok {
+		t.Fatal("expected ok=false for an empty event")
+	}
+}
+
+// TestApplyWritesEmitsPrevData asserts the #commit firehose event advertises
+// the previous commit's MST root as prevData.
+func TestApplyWritesEmitsPrevData(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	root, _ := s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	ctx := context.Background()
+	urepo, err := s.getRepoActorByDid(ctx, acct.Did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+
+	evts, cancel, err := s.evtman.Subscribe(ctx, "test", func(*events.XRPCStreamEvent) bool { return true }, nil)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer cancel()
+
+	rec := MarshalableMap{
+		"$type":     "app.bsky.feed.post",
+		"text":      "hello world",
+		"createdAt": "2024-01-01T00:00:00Z",
+	}
+	if _, err := s.repoman.applyWrites(ctx, urepo.Repo, []Op{{
+		Type:       OpTypeCreate,
+		Collection: "app.bsky.feed.post",
+		Record:     &rec,
+	}}, nil); err != nil {
+		t.Fatalf("applyWrites: %v", err)
+	}
+
+	wantPrev, err := readCommitData(ctx, s.getBlockstore(acct.Did), root)
+	if err != nil {
+		t.Fatalf("readCommitData: %v", err)
+	}
+
+	select {
+	case evt := <-evts:
+		if evt.RepoCommit == nil {
+			t.Fatalf("expected a #commit event, got %+v", evt)
+		}
+		if evt.RepoCommit.PrevData == nil {
+			t.Fatal("RepoCommit.PrevData is nil; want the previous commit's MST root")
+		}
+		if got := cid.Cid(*evt.RepoCommit.PrevData); got != wantPrev {
+			t.Fatalf("prevData = %s, want %s", got, wantPrev)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for #commit event")
+	}
+}
+
+// TestActivateAccountEmitsRepoSync asserts account activation broadcasts a
+// #sync event announcing the repo's current head.
+func TestActivateAccountEmitsRepoSync(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	acct := s.createTestAccount(t, "bob.pds.test")
+	_, rev := s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	ctx := context.Background()
+	urepo, err := s.getRepoActorByDid(ctx, acct.Did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+
+	evts, cancel, err := s.evtman.Subscribe(ctx, "test", func(*events.XRPCStreamEvent) bool { return true }, nil)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer cancel()
+
+	e, rec := newRequestContext(http.MethodPost, "/xrpc/com.atproto.server.activateAccount", "", nil)
+	e.Set("repo", urepo)
+	if err := s.handleServerActivateAccount(e); err != nil {
+		t.Fatalf("handleServerActivateAccount: %v", err)
+	}
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case evt := <-evts:
+			if evt.RepoSync == nil {
+				continue
+			}
+			if evt.RepoSync.Did != acct.Did {
+				t.Fatalf("sync did = %s, want %s", evt.RepoSync.Did, acct.Did)
+			}
+			if evt.RepoSync.Rev != rev {
+				t.Fatalf("sync rev = %s, want %s", evt.RepoSync.Rev, rev)
+			}
+			if len(evt.RepoSync.Blocks) == 0 {
+				t.Fatal("sync blocks are empty; want a CAR with the commit block")
+			}
+			return
+		case <-deadline:
+			t.Fatal("did not observe a #sync event after activation")
+		}
+	}
+}

--- a/server/handle_server_activate_account.go
+++ b/server/handle_server_activate_account.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bluesky-social/indigo/util"
 	"github.com/haileyok/cocoon/internal/helpers"
 	"github.com/haileyok/cocoon/models"
+	"github.com/ipfs/go-cid"
 	"github.com/labstack/echo/v4"
 )
 
@@ -43,6 +44,17 @@ func (s *Server) handleServerActivateAccount(e echo.Context) error {
 			Time:   time.Now().Format(util.ISO8601),
 		},
 	})
+
+	// Announce the repo's current head so relays learn the active account's
+	// authoritative state (Sync v1.1 #sync event).
+	if len(urepo.Repo.Root) > 0 {
+		root, err := cid.Cast(urepo.Repo.Root)
+		if err != nil {
+			logger.Error("error casting repo root for sync event", "error", err)
+		} else if err := s.emitRepoSync(context.TODO(), urepo.Repo.Did, urepo.Repo.Rev, root); err != nil {
+			logger.Error("error emitting repo sync event", "error", err)
+		}
+	}
 
 	return e.NoContent(200)
 }

--- a/server/handle_server_create_account.go
+++ b/server/handle_server_create_account.go
@@ -249,6 +249,10 @@ func (s *Server) handleCreateAccount(e echo.Context) error {
 				Time:   time.Now().Format(util.ISO8601),
 			},
 		})
+
+		if err := s.emitRepoSync(context.TODO(), urepo.Did, rev, root); err != nil {
+			logger.Error("error emitting repo sync event", "error", err)
+		}
 	}
 
 	sess, err := s.createSession(ctx, &urepo)

--- a/server/handle_sync_subscribe_repos.go
+++ b/server/handle_sync_subscribe_repos.go
@@ -12,6 +12,26 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// subscribeReposMsgType maps a stream event to its com.atproto.sync.subscribeRepos
+// message frame type and the object to serialize. The bool is false for events
+// that are not message frames (e.g. error frames, handled separately).
+func subscribeReposMsgType(evt *events.XRPCStreamEvent) (string, util.CBOR, bool) {
+	switch {
+	case evt.RepoCommit != nil:
+		return "#commit", evt.RepoCommit, true
+	case evt.RepoSync != nil:
+		return "#sync", evt.RepoSync, true
+	case evt.RepoIdentity != nil:
+		return "#identity", evt.RepoIdentity, true
+	case evt.RepoAccount != nil:
+		return "#account", evt.RepoAccount, true
+	case evt.RepoInfo != nil:
+		return "#info", evt.RepoInfo, true
+	default:
+		return "", nil, false
+	}
+}
+
 func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
 	ctx, cancel := context.WithCancel(e.Request().Context())
 	defer cancel()
@@ -87,23 +107,15 @@ func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
 			}
 
 			var obj util.CBOR
-			switch {
-			case evt.Error != nil:
+			if evt.Error != nil {
 				header.Op = events.EvtKindErrorFrame
+				header.MsgType = ""
 				obj = evt.Error
-			case evt.RepoCommit != nil:
-				header.MsgType = "#commit"
-				obj = evt.RepoCommit
-			case evt.RepoIdentity != nil:
-				header.MsgType = "#identity"
-				obj = evt.RepoIdentity
-			case evt.RepoAccount != nil:
-				header.MsgType = "#account"
-				obj = evt.RepoAccount
-			case evt.RepoInfo != nil:
-				header.MsgType = "#info"
-				obj = evt.RepoInfo
-			default:
+			} else if msgType, o, ok := subscribeReposMsgType(evt); ok {
+				header.Op = events.EvtKindMessage
+				header.MsgType = msgType
+				obj = o
+			} else {
 				logger.Warn("unrecognized event kind")
 				return
 			}

--- a/server/repo.go
+++ b/server/repo.go
@@ -170,6 +170,23 @@ func openRepo(ctx context.Context, bs blockstore.Blockstore, rootCid cid.Cid, di
 	}, nil
 }
 
+// readCommitData reads the commit block at root and returns its `data` field:
+// the root CID of that commit's MST. This is the value the firehose reports as
+// `prevData` for the next commit.
+func readCommitData(ctx context.Context, bs blockstore.Blockstore, root cid.Cid) (cid.Cid, error) {
+	commitBlock, err := bs.Get(ctx, root)
+	if err != nil {
+		return cid.Undef, fmt.Errorf("reading commit block: %w", err)
+	}
+
+	var commit atp.Commit
+	if err := commit.UnmarshalCBOR(bytes.NewReader(commitBlock.RawData())); err != nil {
+		return cid.Undef, fmt.Errorf("parsing commit block: %w", err)
+	}
+
+	return commit.Data, nil
+}
+
 func commitRepo(ctx context.Context, bs blockstore.Blockstore, r *atp.Repo, signingKey []byte) (cid.Cid, string, error) {
 	if _, err := r.MST.WriteDiffBlocks(ctx, bs); err != nil {
 		return cid.Undef, "", fmt.Errorf("writing MST blocks: %w", err)
@@ -242,6 +259,15 @@ func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []
 
 	dbs := rm.s.getBlockstore(urepo.Did)
 	bs := recording_blockstore.New(dbs)
+
+	// Capture the previous commit's MST root so the firehose can advertise it as
+	// prevData (required for the inductive firehose). applyWrites always runs on
+	// an existing repo, so there is always a previous commit to read.
+	prevData, err := readCommitData(ctx, dbs, rootcid)
+	if err != nil {
+		return nil, err
+	}
+	prevDataLink := lexutil.LexLink(prevData)
 
 	var results []ApplyWriteResult
 	var ops []*atp.Operation
@@ -519,15 +545,16 @@ func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []
 	// runs sync or not
 	rm.s.evtman.AddEvent(context.Background(), &events.XRPCStreamEvent{
 		RepoCommit: &atproto.SyncSubscribeRepos_Commit{
-			Repo:   urepo.Did,
-			Blocks: buf.Bytes(),
-			Blobs:  blobs,
-			Rev:    rev,
-			Since:  &urepo.Rev,
-			Commit: lexutil.LexLink(newroot),
-			Time:   time.Now().Format(time.RFC3339Nano),
-			Ops:    repoOps,
-			TooBig: false,
+			Repo:     urepo.Did,
+			Blocks:   buf.Bytes(),
+			Blobs:    blobs,
+			Rev:      rev,
+			Since:    &urepo.Rev,
+			Commit:   lexutil.LexLink(newroot),
+			PrevData: &prevDataLink,
+			Time:     time.Now().Format(time.RFC3339Nano),
+			Ops:      repoOps,
+			TooBig:   false,
 		},
 	})
 

--- a/server/repo_sync.go
+++ b/server/repo_sync.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/carstore"
+	"github.com/bluesky-social/indigo/events"
+	"github.com/ipfs/go-cid"
+	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/ipld/go-car"
+)
+
+// buildSyncCar serializes a single-block CAR containing the signed commit at
+// root. The CAR header lists the commit CID as its first root, as required by
+// the com.atproto.sync.subscribeRepos #sync event.
+func (s *Server) buildSyncCar(ctx context.Context, did string, root cid.Cid) ([]byte, error) {
+	bs := s.getBlockstore(did)
+
+	buf := new(bytes.Buffer)
+	hb, err := cbor.DumpObject(&car.CarHeader{
+		Roots:   []cid.Cid{root},
+		Version: 1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if _, err := carstore.LdWrite(buf, hb); err != nil {
+		return nil, err
+	}
+
+	blk, err := bs.Get(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := carstore.LdWrite(buf, blk.Cid().Bytes(), blk.RawData()); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// emitRepoSync broadcasts a #sync event announcing the repo's current head. Per
+// Sync v1.1 this authoritatively advertises the repo's latest commit so relays
+// can recover state without replaying the commit stream.
+func (s *Server) emitRepoSync(ctx context.Context, did, rev string, root cid.Cid) error {
+	blocks, err := s.buildSyncCar(ctx, did, root)
+	if err != nil {
+		return err
+	}
+
+	s.evtman.AddEvent(ctx, &events.XRPCStreamEvent{
+		RepoSync: &atproto.SyncSubscribeRepos_Sync{
+			Did:    did,
+			Rev:    rev,
+			Blocks: blocks,
+			Time:   time.Now().Format(time.RFC3339Nano),
+		},
+	})
+
+	return nil
+}


### PR DESCRIPTION
## What

Implements the inductive-firehose pieces of [atproto Sync v1.1](https://atproto.com/specs/sync). Fixes pdscheck warnings **W1** (missing `prevData`) and **W2** (no `#sync` events) against hailey.at.

## Changes

### `prevData` on `#commit` (W1)
`server/repo.go`: `applyWrites` now reads the previous commit block (via a new `readCommitData` helper) and sets `PrevData` — the root CID of the previous commit's MST — on the emitted `SyncSubscribeRepos_Commit`. Genesis commits in `createAccount` have no predecessor and remain without `prevData`.

### `#sync` events (W2)
- `server/repo_sync.go` (new): `emitRepoSync` broadcasts a `SyncSubscribeRepos_Sync` carrying a single-block CAR of the signed commit at the repo's current head (`buildSyncCar`, reusing the `carstore.LdWrite` pattern).
- Emission points: **account creation** (genesis, `handle_server_create_account.go`) and **account activation** (`handle_server_activate_account.go`).
- Relay: `handle_sync_subscribe_repos.go` now maps `RepoSync` → `#sync`. The frame-type switch was extracted into a pure, testable `subscribeReposMsgType` mapper; error-frame handling is unchanged. (`persist.go` already serialized/replayed `RepoSync`.)

`Seq` is assigned by the persister, consistent with the other event types.

## Tests

`server/firehose_sync_test.go`:
- `TestSubscribeReposMsgType` — relay mapper covers `#commit`/`#sync`/`#identity`/`#account`/`#info` and returns `ok=false` for empty events.
- `TestApplyWritesEmitsPrevData` — drives a write through `applyWrites` on a seeded genesis repo and asserts the `#commit` event's `PrevData` equals the genesis commit's MST root.
- `TestActivateAccountEmitsRepoSync` — asserts activation broadcasts a `#sync` with the correct `did`/`rev` and a non-empty CAR.

Both integration tests were confirmed to go **red** when the production behavior is reverted (vacuity check), then green with it restored. `go vet ./...` and `go test -race ./...` pass; gofmt clean.

## Verification note

W1/W2 will show as passing in pdscheck once the verifier samples a fresh commit / activation after deploy.