### PR TITLE
fix: getBlocks parses string cids with cid.Decode

### DIFF
--- a/server/handle_sync_get_blocks.go
+++ b/server/handle_sync_get_blocks.go
@@ -29,7 +29,7 @@ func (s *Server) handleGetBlocks(e echo.Context) error {
 	var cids []cid.Cid
 
 	for _, cs := range req.Cids {
-		c, err := cid.Cast([]byte(cs))
+		c, err := cid.Decode(cs)
 		if err != nil {
 			return helpers.InputError(e, to.StringPtr("InvalidRequest"))
 		}

--- a/server/handle_sync_get_blocks_happy_test.go
+++ b/server/handle_sync_get_blocks_happy_test.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestHandleGetBlocksReturnsCar requests a block by its string CID (as the
+// lexicon specifies) and expects a CAR response, not a 400.
+func TestHandleGetBlocksReturnsCar(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	root, _ := s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	target := "/xrpc/com.atproto.sync.getBlocks?did=" + acct.Did + "&cids=" + root.String()
+	e, rec := newRequestContext(http.MethodGet, target, "", nil)
+	if err := s.handleGetBlocks(e); err != nil {
+		t.Fatalf("handleGetBlocks: %v", err)
+	}
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("content-type"); ct != "application/vnd.ipld.car" {
+		t.Fatalf("content-type = %q, want application/vnd.ipld.car", ct)
+	}
+	if rec.Body.Len() == 0 {
+		t.Fatal("empty CAR body")
+	}
+}


### PR DESCRIPTION
## What

`com.atproto.sync.getBlocks` returned **400 InvalidRequest for valid requests**. The `cids` query param carries base32 CID **strings** (e.g. `bafyrei...`), but the handler parsed them with `cid.Cast([]byte(cs))` — `Cast` expects the raw *binary* CID form, so every string CID failed to parse.

PR #106 made that parse failure return 400 (instead of 500), which is correct for genuinely bad input, but the happy path was always broken. pdscheck's `sync.get-blocks` check sends a real CID and now fails with 400.

## Change

`server/handle_sync_get_blocks.go`: parse each requested cid with `cid.Decode(cs)` instead of `cid.Cast([]byte(cs))`. Unparseable cids still return 400 `InvalidRequest`.

(`cid.Cast(urepo.Root)` for the CAR header root is unchanged — `Root` is stored as raw bytes, so `Cast` is correct there.)

## Test

- `TestHandleGetBlocksReturnsCar` (new) — seeds a genesis repo and requests its root by string CID; asserts 200 with `application/vnd.ipld.car` and a non-empty body. Confirmed red (400) before the fix, green after.
- `TestHandleGetBlocksBadCid` (existing) — `cids=undefined` still returns 400 `InvalidRequest`.

`go vet ./...` and `go test -race ./server/` pass; gofmt clean.