### PR TITLE
fix: getRecord 404 includes 'Could not locate record' message

### DIFF
--- a/server/handle_repo_get_record.go
+++ b/server/handle_repo_get_record.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/bluesky-social/indigo/atproto/atdata"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/haileyok/cocoon/internal/helpers"
@@ -43,7 +42,11 @@ func (s *Server) handleRepoGetRecord(e echo.Context) error {
 	// A zero-row Scan leaves record zero-valued without an error, so an empty
 	// Did means the record is not stored on this PDS.
 	if record.Did == "" {
-		return helpers.InputError(e, to.StringPtr("RecordNotFound"))
+		uri := "at://" + repo + "/" + collection + "/" + rkey
+		return e.JSON(400, map[string]string{
+			"error":   "RecordNotFound",
+			"message": "Could not locate record: " + uri,
+		})
 	}
 
 	val, err := atdata.UnmarshalCBOR(record.Value)

--- a/server/handle_repo_get_record_test.go
+++ b/server/handle_repo_get_record_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/bluesky-social/indigo/atproto/atdata"
@@ -96,5 +97,11 @@ func TestHandleRepoGetRecordNotFound(t *testing.T) {
 	}
 	if body["error"] != "RecordNotFound" {
 		t.Fatalf("error = %q, want RecordNotFound; body=%s", body["error"], rec.Body.String())
+	}
+	// Bluesky's social-app substring-matches this phrase to detect a missing
+	// (e.g. detached-quote) record, so the message must carry the at-uri.
+	wantURI := "at://" + acct.Did + "/" + nsid + "/doesnotexist"
+	if msg := body["message"]; !strings.Contains(msg, "Could not locate record: "+wantURI) {
+		t.Fatalf("message = %q, want it to contain %q; body=%s", msg, "Could not locate record: "+wantURI, rec.Body.String())
 	}
 }


### PR DESCRIPTION
## What

`com.atproto.repo.getRecord` for a missing record returned `{"error":"RecordNotFound"}` (status 400) — correct code, but no `message`. pdscheck's `repo-read.get-record-missing` check requires the message to include `"Could not locate record: <at-uri>"`, the phrase Bluesky's social-app substring-matches when handling missing/detached-quote records.

Follow-up to PR #105 (which fixed the status/error code).

## Change

`server/handle_repo_get_record.go`: the not-found branch now returns
```json
{ "error": "RecordNotFound", "message": "Could not locate record: at://<repo>/<collection>/<rkey>" }
```
with status 400. (Removed the now-unused `to` import.)

## Test

`TestHandleRepoGetRecordNotFound` now also asserts the `message` contains `Could not locate record: <at-uri>`. Confirmed red (empty message) before the fix, green after. `go vet ./...` and `go test -race ./server/` pass; gofmt clean.