### PR TITLE
fix: applyWrites create+delete of same rkey no longer 500s

### DIFF
--- a/server/apply_writes_create_delete_test.go
+++ b/server/apply_writes_create_delete_test.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"context"
+	"testing"
+)
+
+func newApplyWritesServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+	return s, acct.Did
+}
+
+func postRecord(text string) MarshalableMap {
+	return MarshalableMap{
+		"$type":     "app.bsky.feed.post",
+		"text":      text,
+		"createdAt": "2024-01-01T00:00:00Z",
+	}
+}
+
+// TestApplyWritesCreateThenDeleteSameRkey reproduces the atomic create+delete
+// applyWrites path (create rkey A and delete rkey A in one batch).
+func TestApplyWritesCreateThenDeleteSameRkey(t *testing.T) {
+	ctx := context.Background()
+	s, did := newApplyWritesServer(t)
+	urepo, err := s.getRepoActorByDid(ctx, did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+
+	rkey := "3laaaaaaaaa2x"
+	rec := postRecord("hello")
+	ops := []Op{
+		{Type: OpTypeCreate, Collection: "app.bsky.feed.post", Rkey: &rkey, Record: &rec},
+		{Type: OpTypeDelete, Collection: "app.bsky.feed.post", Rkey: &rkey},
+	}
+	if _, err := s.repoman.applyWrites(ctx, urepo.Repo, ops, nil); err != nil {
+		t.Fatalf("applyWrites create+delete (same rkey): %v", err)
+	}
+}
+
+// TestApplyWritesCreateAndDeleteOther creates a new record and deletes a
+// pre-existing record in one atomic batch.
+func TestApplyWritesCreateAndDeleteOther(t *testing.T) {
+	ctx := context.Background()
+	s, did := newApplyWritesServer(t)
+	urepo, err := s.getRepoActorByDid(ctx, did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+
+	// Seed an existing record B.
+	rkeyB := "3lbbbbbbbbb2x"
+	recB := postRecord("first")
+	if _, err := s.repoman.applyWrites(ctx, urepo.Repo, []Op{
+		{Type: OpTypeCreate, Collection: "app.bsky.feed.post", Rkey: &rkeyB, Record: &recB},
+	}, nil); err != nil {
+		t.Fatalf("seed record B: %v", err)
+	}
+
+	// Reload repo head/rev.
+	urepo, err = s.getRepoActorByDid(ctx, did)
+	if err != nil {
+		t.Fatalf("reload repo: %v", err)
+	}
+
+	// Atomic: create A, delete B.
+	rkeyA := "3laaaaaaaaa2x"
+	recA := postRecord("second")
+	if _, err := s.repoman.applyWrites(ctx, urepo.Repo, []Op{
+		{Type: OpTypeCreate, Collection: "app.bsky.feed.post", Rkey: &rkeyA, Record: &recA},
+		{Type: OpTypeDelete, Collection: "app.bsky.feed.post", Rkey: &rkeyB},
+	}, nil); err != nil {
+		t.Fatalf("applyWrites create A + delete B: %v", err)
+	}
+}

--- a/server/repo.go
+++ b/server/repo.go
@@ -719,6 +719,13 @@ func (rm *RepoMan) decrementBlobRefs(ctx context.Context, urepo models.Repo, cbo
 func getBlobCidsFromCbor(cbor []byte) ([]cid.Cid, error) {
 	var cids []cid.Cid
 
+	// A deleted record whose prior value isn't on hand (e.g. a create+delete of
+	// the same rkey in one batch, where the create isn't yet persisted) has no
+	// known blob references to account for.
+	if len(cbor) == 0 {
+		return nil, nil
+	}
+
 	decoded, err := atdata.UnmarshalCBOR(cbor)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling cbor: %w", err)


### PR DESCRIPTION
## What

`com.atproto.repo.applyWrites` returned **500 Internal server error** for an atomic batch that creates and deletes the **same rkey** (pdscheck `repo-write.apply-writes`).

## Root cause

In `applyWrites`, the delete branch loads the record's prior value from the `records` table to compute blob-ref decrements. But within a single batch the create isn't persisted until after the commit closure, so for a create+delete of the same rkey the lookup returns **nothing** and the delete entry's `Value` is nil. `decrementBlobRefs(nil)` → `getBlobCidsFromCbor(nil)` → `atdata.UnmarshalCBOR(nil)` → `EOF` → 500.

(Create+delete of *different* rkeys was unaffected and is covered by a passing test.)

## Fix

`server/repo.go`: guard `getBlobCidsFromCbor` against empty input — an unknown/absent prior value has no blob references to adjust, so return `nil, nil`.

## Tests (`server/apply_writes_create_delete_test.go`)

- `TestApplyWritesCreateThenDeleteSameRkey` — create + delete the same rkey in one batch. Reproduced the `EOF` 500 before the fix; passes after.
- `TestApplyWritesCreateAndDeleteOther` — create A + delete pre-existing B atomically (regression guard; passed before and after).

`go vet ./...` and `go test -race ./server/` pass; gofmt clean.