### PR TITLE
feat(oauth): granular scope parsing + PAR scope validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
+	github.com/rivo/uniseg v0.1.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/samber/lo v1.53.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -481,6 +481,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/oauth/scopes/parser.go
+++ b/oauth/scopes/parser.go
@@ -1,0 +1,279 @@
+// Package scopes parses and validates atproto OAuth permission scopes
+// (proposal 0011-auth-scopes). It models the granular resources (repo, rpc,
+// blob, account, identity, include) alongside the legacy static scopes
+// (atproto, transition:*), and exposes enough structure for PAR-time validation
+// and resource-server enforcement.
+package scopes
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/bluesky-social/indigo/atproto/syntax"
+)
+
+// Resource identifiers for parsed scopes.
+const (
+	ResourceRepo       = "repo"
+	ResourceRPC        = "rpc"
+	ResourceBlob       = "blob"
+	ResourceAccount    = "account"
+	ResourceIdentity   = "identity"
+	ResourceInclude    = "include"
+	ResourceAtproto    = "atproto"
+	ResourceTransition = "transition"
+)
+
+// repoActions are the valid repo write actions.
+var repoActions = map[string]bool{"create": true, "update": true, "delete": true}
+
+// transitionValues are the accepted legacy transition scope suffixes.
+var transitionValues = map[string]bool{"generic": true, "email": true, "chat.bsky": true}
+
+// Scope is a single parsed scope token. Only the fields relevant to its
+// Resource are populated.
+type Scope struct {
+	Raw      string
+	Resource string
+
+	// repo
+	Collections []string
+	Actions     []string
+
+	// rpc
+	Lxm []string
+	Aud string
+
+	// blob
+	Accept []string
+
+	// account / identity
+	Attr   string
+	Action string
+
+	// include
+	Nsid string
+
+	// transition:<value>
+	Transition string
+}
+
+// ParseList splits a space-delimited scope string and parses each token. It
+// returns an error on the first token that fails to parse.
+func ParseList(scope string) ([]*Scope, error) {
+	fields := strings.Fields(scope)
+	out := make([]*Scope, 0, len(fields))
+	for _, f := range fields {
+		s, err := Parse(f)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// Parse parses a single scope token, returning an error if it is syntactically
+// invalid or uses a disallowed wildcard combination.
+func Parse(raw string) (*Scope, error) {
+	if raw == "" {
+		return nil, fmt.Errorf("empty scope")
+	}
+
+	if raw == ResourceAtproto {
+		return &Scope{Raw: raw, Resource: ResourceAtproto}, nil
+	}
+
+	left := raw
+	query := ""
+	if i := strings.IndexByte(raw, '?'); i >= 0 {
+		left, query = raw[:i], raw[i+1:]
+	}
+
+	resource := left
+	positional := ""
+	hasPositional := false
+	if i := strings.IndexByte(left, ':'); i >= 0 {
+		resource, positional = left[:i], left[i+1:]
+		hasPositional = true
+	}
+
+	if resource == ResourceTransition {
+		if !hasPositional || positional == "" {
+			return nil, fmt.Errorf("transition scope %q is missing a value", raw)
+		}
+		if query != "" {
+			return nil, fmt.Errorf("transition scope %q must not have parameters", raw)
+		}
+		if !transitionValues[positional] {
+			return nil, fmt.Errorf("unknown transition scope %q", raw)
+		}
+		return &Scope{Raw: raw, Resource: ResourceTransition, Transition: positional}, nil
+	}
+
+	params, err := url.ParseQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("invalid scope parameters in %q: %w", raw, err)
+	}
+
+	switch resource {
+	case ResourceRepo:
+		return parseRepo(raw, positional, hasPositional, params)
+	case ResourceRPC:
+		return parseRPC(raw, positional, hasPositional, params)
+	case ResourceBlob:
+		return parseBlob(raw, positional, hasPositional, params)
+	case ResourceAccount:
+		return parseAccount(raw, positional, hasPositional, params)
+	case ResourceIdentity:
+		return parseIdentity(raw, positional, hasPositional, params)
+	case ResourceInclude:
+		return parseInclude(raw, positional, hasPositional, params)
+	default:
+		return nil, fmt.Errorf("unknown scope resource %q", resource)
+	}
+}
+
+func parseRepo(raw, positional string, hasPositional bool, params url.Values) (*Scope, error) {
+	var collections []string
+	if hasPositional && positional != "" {
+		collections = append(collections, positional)
+	}
+	collections = append(collections, params["collection"]...)
+	if len(collections) == 0 {
+		return nil, fmt.Errorf("repo scope %q requires a collection", raw)
+	}
+	for _, c := range collections {
+		if c == "*" {
+			continue
+		}
+		if _, err := syntax.ParseNSID(c); err != nil {
+			return nil, fmt.Errorf("repo scope %q has invalid collection %q: %w", raw, c, err)
+		}
+	}
+
+	actions := params["action"]
+	for _, a := range actions {
+		if a == "*" {
+			return nil, fmt.Errorf("repo scope %q must not use action=*", raw)
+		}
+		if !repoActions[a] {
+			return nil, fmt.Errorf("repo scope %q has invalid action %q", raw, a)
+		}
+	}
+	if len(actions) == 0 {
+		actions = []string{"create", "update", "delete"}
+	}
+
+	return &Scope{Raw: raw, Resource: ResourceRepo, Collections: collections, Actions: actions}, nil
+}
+
+func parseRPC(raw, positional string, hasPositional bool, params url.Values) (*Scope, error) {
+	var lxm []string
+	if hasPositional && positional != "" {
+		lxm = append(lxm, positional)
+	}
+	lxm = append(lxm, params["lxm"]...)
+	if len(lxm) == 0 {
+		return nil, fmt.Errorf("rpc scope %q requires an lxm", raw)
+	}
+	hasWildcardLxm := false
+	for _, l := range lxm {
+		if l == "*" {
+			hasWildcardLxm = true
+			continue
+		}
+		if _, err := syntax.ParseNSID(l); err != nil {
+			return nil, fmt.Errorf("rpc scope %q has invalid lxm %q: %w", raw, l, err)
+		}
+	}
+
+	aud := params.Get("aud")
+	if aud == "" {
+		return nil, fmt.Errorf("rpc scope %q requires an aud", raw)
+	}
+	if hasWildcardLxm && aud == "*" {
+		return nil, fmt.Errorf("rpc scope %q must not use both lxm=* and aud=*", raw)
+	}
+
+	return &Scope{Raw: raw, Resource: ResourceRPC, Lxm: lxm, Aud: aud}, nil
+}
+
+func parseBlob(raw, positional string, hasPositional bool, params url.Values) (*Scope, error) {
+	var accept []string
+	if hasPositional && positional != "" {
+		accept = append(accept, positional)
+	}
+	accept = append(accept, params["accept"]...)
+	if len(accept) == 0 {
+		return nil, fmt.Errorf("blob scope %q requires an accept pattern", raw)
+	}
+	return &Scope{Raw: raw, Resource: ResourceBlob, Accept: accept}, nil
+}
+
+func parseAccount(raw, positional string, hasPositional bool, params url.Values) (*Scope, error) {
+	if !hasPositional || positional == "" {
+		return nil, fmt.Errorf("account scope %q requires an attribute", raw)
+	}
+	if positional != "email" && positional != "repo" {
+		return nil, fmt.Errorf("account scope %q has invalid attribute %q", raw, positional)
+	}
+	action := params.Get("action")
+	switch action {
+	case "", "read":
+		action = "read"
+	case "manage":
+		// only repo supports manage
+		if positional != "repo" {
+			return nil, fmt.Errorf("account scope %q does not support action=manage", raw)
+		}
+	default:
+		return nil, fmt.Errorf("account scope %q has invalid action %q", raw, action)
+	}
+	return &Scope{Raw: raw, Resource: ResourceAccount, Attr: positional, Action: action}, nil
+}
+
+func parseIdentity(raw, positional string, hasPositional bool, params url.Values) (*Scope, error) {
+	if !hasPositional || positional == "" {
+		return nil, fmt.Errorf("identity scope %q requires an attribute", raw)
+	}
+	if positional != "handle" && positional != "*" {
+		return nil, fmt.Errorf("identity scope %q has invalid attribute %q", raw, positional)
+	}
+	return &Scope{Raw: raw, Resource: ResourceIdentity, Attr: positional}, nil
+}
+
+func parseInclude(raw, positional string, hasPositional bool, params url.Values) (*Scope, error) {
+	if !hasPositional || positional == "" {
+		return nil, fmt.Errorf("include scope %q requires an nsid", raw)
+	}
+	if _, err := syntax.ParseNSID(positional); err != nil {
+		return nil, fmt.Errorf("include scope %q has invalid nsid %q: %w", raw, positional, err)
+	}
+	return &Scope{Raw: raw, Resource: ResourceInclude, Nsid: positional, Aud: params.Get("aud")}, nil
+}
+
+// AllowsRepoWrite reports whether this scope grants the given repo write action
+// on the given collection. Non-repo scopes always return false.
+func (s *Scope) AllowsRepoWrite(collection, action string) bool {
+	if s.Resource != ResourceRepo {
+		return false
+	}
+	hasAction := false
+	for _, a := range s.Actions {
+		if a == action {
+			hasAction = true
+			break
+		}
+	}
+	if !hasAction {
+		return false
+	}
+	for _, c := range s.Collections {
+		if c == "*" || c == collection {
+			return true
+		}
+	}
+	return false
+}

--- a/oauth/scopes/parser_test.go
+++ b/oauth/scopes/parser_test.go
@@ -1,0 +1,143 @@
+package scopes
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseValid(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want *Scope
+	}{
+		{"atproto", &Scope{Raw: "atproto", Resource: ResourceAtproto}},
+		{"transition:generic", &Scope{Raw: "transition:generic", Resource: ResourceTransition, Transition: "generic"}},
+		{"transition:email", &Scope{Raw: "transition:email", Resource: ResourceTransition, Transition: "email"}},
+		{"transition:chat.bsky", &Scope{Raw: "transition:chat.bsky", Resource: ResourceTransition, Transition: "chat.bsky"}},
+		{
+			"repo:app.bsky.feed.post",
+			&Scope{Raw: "repo:app.bsky.feed.post", Resource: ResourceRepo, Collections: []string{"app.bsky.feed.post"}, Actions: []string{"create", "update", "delete"}},
+		},
+		{
+			"repo:app.bsky.feed.post?action=create",
+			&Scope{Raw: "repo:app.bsky.feed.post?action=create", Resource: ResourceRepo, Collections: []string{"app.bsky.feed.post"}, Actions: []string{"create"}},
+		},
+		{
+			"repo:*",
+			&Scope{Raw: "repo:*", Resource: ResourceRepo, Collections: []string{"*"}, Actions: []string{"create", "update", "delete"}},
+		},
+		{
+			"rpc:app.bsky.feed.getFeed?aud=did:web:api.bsky.app%23svc_appview",
+			&Scope{Raw: "rpc:app.bsky.feed.getFeed?aud=did:web:api.bsky.app%23svc_appview", Resource: ResourceRPC, Lxm: []string{"app.bsky.feed.getFeed"}, Aud: "did:web:api.bsky.app#svc_appview"},
+		},
+		{
+			"rpc:*?aud=did:web:api.bsky.app%23svc_appview",
+			&Scope{Raw: "rpc:*?aud=did:web:api.bsky.app%23svc_appview", Resource: ResourceRPC, Lxm: []string{"*"}, Aud: "did:web:api.bsky.app#svc_appview"},
+		},
+		{
+			"include:site.standard.authFull",
+			&Scope{Raw: "include:site.standard.authFull", Resource: ResourceInclude, Nsid: "site.standard.authFull"},
+		},
+		{
+			"include:site.standard.authFull?aud=did:web:api.bsky.app%23svc",
+			&Scope{Raw: "include:site.standard.authFull?aud=did:web:api.bsky.app%23svc", Resource: ResourceInclude, Nsid: "site.standard.authFull", Aud: "did:web:api.bsky.app#svc"},
+		},
+		{
+			"blob:image/*",
+			&Scope{Raw: "blob:image/*", Resource: ResourceBlob, Accept: []string{"image/*"}},
+		},
+		{
+			"account:email",
+			&Scope{Raw: "account:email", Resource: ResourceAccount, Attr: "email", Action: "read"},
+		},
+		{
+			"account:repo?action=manage",
+			&Scope{Raw: "account:repo?action=manage", Resource: ResourceAccount, Attr: "repo", Action: "manage"},
+		},
+		{
+			"identity:*",
+			&Scope{Raw: "identity:*", Resource: ResourceIdentity, Attr: "*"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, err := Parse(tt.raw)
+			if err != nil {
+				t.Fatalf("Parse(%q) unexpected error: %v", tt.raw, err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Parse(%q) = %+v, want %+v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	invalid := []string{
+		"",
+		"bogus",
+		"transition:bogus",
+		"transition:",
+		"repo",
+		"repo:not a nsid",
+		"repo:app.bsky.feed.post?action=*",
+		"repo:app.bsky.feed.post?action=bogus",
+		"rpc:app.bsky.feed.getFeed", // missing aud
+		"rpc:*?aud=*",
+		"rpc:not a nsid?aud=did:web:x",
+		"include:not_a_valid_nsid",
+		"include:",
+		"account:bogus",
+		"account:email?action=manage",
+		"identity:bogus",
+	}
+
+	for _, raw := range invalid {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := Parse(raw); err == nil {
+				t.Fatalf("Parse(%q) expected error, got nil", raw)
+			}
+		})
+	}
+}
+
+func TestParseListRejectsBadToken(t *testing.T) {
+	if _, err := ParseList("atproto repo:app.bsky.feed.post include:not_a_valid_nsid"); err == nil {
+		t.Fatal("expected ParseList to fail on an invalid token")
+	}
+	got, err := ParseList("atproto transition:generic repo:app.bsky.feed.post")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 parsed scopes, got %d", len(got))
+	}
+}
+
+func TestAllowsRepoWrite(t *testing.T) {
+	tests := []struct {
+		scope      string
+		collection string
+		action     string
+		want       bool
+	}{
+		{"repo:app.bsky.feed.post", "app.bsky.feed.post", "create", true},
+		{"repo:app.bsky.feed.post", "app.bsky.feed.post", "delete", true},
+		{"repo:app.bsky.feed.post?action=create", "app.bsky.feed.post", "delete", false},
+		{"repo:app.bsky.feed.post", "app.bsky.feed.like", "create", false},
+		{"repo:*", "anything.at.all", "update", true},
+		{"rpc:app.bsky.feed.getFeed?aud=did:web:x", "app.bsky.feed.post", "create", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.scope, func(t *testing.T) {
+			sc, err := Parse(tt.scope)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := sc.AllowsRepoWrite(tt.collection, tt.action); got != tt.want {
+				t.Fatalf("AllowsRepoWrite(%q,%q) = %v, want %v", tt.collection, tt.action, got, tt.want)
+			}
+		})
+	}
+}

--- a/oauth/scopes/resolver.go
+++ b/oauth/scopes/resolver.go
@@ -1,0 +1,107 @@
+package scopes
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/lexicon"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+)
+
+// PermissionSetResolver resolves an `include:<nsid>` scope to its permission-set
+// lexicon. ResolvePermissionSet returns nil when the NSID resolves to a valid
+// permission-set record, or an error otherwise.
+type PermissionSetResolver interface {
+	ResolvePermissionSet(ctx context.Context, nsid string) error
+}
+
+// directory is the subset of indigo's identity.Directory used here.
+type directory = identity.Directory
+
+type cacheEntry struct {
+	err     error
+	expires time.Time
+}
+
+// IndigoResolver resolves permission sets using indigo's lexicon resolution
+// (DNS TXT `_lexicon.<authority>` -> DID -> `com.atproto.lexicon.schema`
+// record), with a small in-memory TTL cache for both positive and negative
+// results.
+type IndigoResolver struct {
+	dir directory
+
+	posTTL time.Duration
+	negTTL time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cacheEntry
+}
+
+// NewIndigoResolver builds a resolver backed by the default identity directory.
+func NewIndigoResolver() *IndigoResolver {
+	return NewIndigoResolverWithDirectory(identity.DefaultDirectory())
+}
+
+// NewIndigoResolverWithDirectory builds a resolver using the supplied directory.
+func NewIndigoResolverWithDirectory(dir directory) *IndigoResolver {
+	return &IndigoResolver{
+		dir:    dir,
+		posTTL: time.Hour,
+		negTTL: time.Minute,
+		cache:  map[string]cacheEntry{},
+	}
+}
+
+func (r *IndigoResolver) ResolvePermissionSet(ctx context.Context, nsidStr string) error {
+	if cached, ok := r.lookup(nsidStr); ok {
+		return cached
+	}
+
+	err := r.resolve(ctx, nsidStr)
+	r.store(nsidStr, err)
+	return err
+}
+
+func (r *IndigoResolver) resolve(ctx context.Context, nsidStr string) error {
+	nsid, err := syntax.ParseNSID(nsidStr)
+	if err != nil {
+		return fmt.Errorf("invalid nsid %q: %w", nsidStr, err)
+	}
+
+	sf, err := lexicon.ResolveLexiconSchemaFile(ctx, r.dir, nsid)
+	if err != nil {
+		return fmt.Errorf("could not resolve permission set %q: %w", nsidStr, err)
+	}
+
+	main, ok := sf.Defs["main"]
+	if !ok {
+		return fmt.Errorf("lexicon %q has no main definition", nsidStr)
+	}
+	if _, ok := main.Inner.(lexicon.SchemaPermissionSet); !ok {
+		return fmt.Errorf("lexicon %q main definition is not a permission-set", nsidStr)
+	}
+	return nil
+}
+
+func (r *IndigoResolver) lookup(nsid string) (error, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	entry, ok := r.cache[nsid]
+	if !ok || time.Now().After(entry.expires) {
+		return nil, false
+	}
+	return entry.err, true
+}
+
+func (r *IndigoResolver) store(nsid string, err error) {
+	ttl := r.posTTL
+	if err != nil {
+		ttl = r.negTTL
+	}
+	r.mu.Lock()
+	r.cache[nsid] = cacheEntry{err: err, expires: time.Now().Add(ttl)}
+	r.mu.Unlock()
+}

--- a/server/handle_oauth_authorize.go
+++ b/server/handle_oauth_authorize.go
@@ -70,6 +70,14 @@ func (s *Server) handleOauthAuthorizeGet(e echo.Context) error {
 			return helpers.ServerError(e, to.StringPtr(err.Error()))
 		}
 
+		if err := s.validateRequestedScopes(ctx, parRequest.Scope); err != nil {
+			s.logger.Error("invalid requested scope", "client_id", parRequest.ClientID, "scope", parRequest.Scope, "error", err)
+			return e.JSON(400, map[string]string{
+				"error":             "invalid_scope",
+				"error_description": err.Error(),
+			})
+		}
+
 		if parRequest.DpopJkt == nil {
 			if client.Metadata.DpopBoundAccessTokens {
 			}

--- a/server/handle_oauth_par.go
+++ b/server/handle_oauth_par.go
@@ -61,6 +61,14 @@ func (s *Server) handleOauthPar(e echo.Context) error {
 		return helpers.InputError(e, to.StringPtr(err.Error()))
 	}
 
+	if err := s.validateRequestedScopes(ctx, parRequest.Scope); err != nil {
+		logger.Error("invalid requested scope", "client_id", parRequest.ClientID, "scope", parRequest.Scope, "error", err)
+		return e.JSON(400, map[string]string{
+			"error":             "invalid_scope",
+			"error_description": err.Error(),
+		})
+	}
+
 	if parRequest.DpopJkt == nil {
 		if client.Metadata.DpopBoundAccessTokens {
 			parRequest.DpopJkt = to.StringPtr(dpopProof.JKT)

--- a/server/scope_validation.go
+++ b/server/scope_validation.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/haileyok/cocoon/oauth/scopes"
+)
+
+// validateRequestedScopes parses the requested scope string and rejects any
+// syntactically-invalid scope. Each `include:<nsid>` is resolved against the
+// permission-set resolver; an include that does not resolve to a real
+// permission-set lexicon is rejected. When no resolver is configured, include
+// resolution is skipped (parsing/syntactic validation still applies).
+func (s *Server) validateRequestedScopes(ctx context.Context, scope string) error {
+	parsed, err := scopes.ParseList(scope)
+	if err != nil {
+		return err
+	}
+
+	for _, sc := range parsed {
+		if sc.Resource != scopes.ResourceInclude {
+			continue
+		}
+		if s.scopeResolver == nil {
+			continue
+		}
+		if err := s.scopeResolver.ResolvePermissionSet(ctx, sc.Nsid); err != nil {
+			return fmt.Errorf("include scope %q could not be resolved: %w", sc.Raw, err)
+		}
+	}
+
+	return nil
+}

--- a/server/scope_validation_test.go
+++ b/server/scope_validation_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/haileyok/cocoon/internal/helpers"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+)
+
+// newTestDpopProof builds a signed DPoP proof JWT acceptable to the server's
+// DpopManager: a fresh ES256 key, the public JWK in the header, and a nonce
+// drawn from the provider so the proof passes nonce validation.
+func newTestDpopProof(t *testing.T, s *Server, method, htu string) string {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate dpop key: %v", err)
+	}
+	pub, err := jwk.FromRaw(priv.Public())
+	if err != nil {
+		t.Fatalf("build public jwk: %v", err)
+	}
+	pubBytes, err := json.Marshal(pub)
+	if err != nil {
+		t.Fatalf("marshal public jwk: %v", err)
+	}
+	var jwkMap map[string]any
+	if err := json.Unmarshal(pubBytes, &jwkMap); err != nil {
+		t.Fatalf("unmarshal public jwk: %v", err)
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
+		"iat":   time.Now().Unix(),
+		"jti":   helpers.RandomVarchar(20),
+		"htm":   method,
+		"htu":   htu,
+		"nonce": s.oauthProvider.NextNonce(),
+	})
+	token.Header["typ"] = "dpop+jwt"
+	token.Header["jwk"] = jwkMap
+
+	signed, err := token.SignedString(priv)
+	if err != nil {
+		t.Fatalf("sign dpop proof: %v", err)
+	}
+	return signed
+}
+
+// stubResolver is a hermetic PermissionSetResolver: only NSIDs in valid resolve.
+type stubResolver struct {
+	valid map[string]bool
+}
+
+func (r stubResolver) ResolvePermissionSet(ctx context.Context, nsid string) error {
+	if r.valid[nsid] {
+		return nil
+	}
+	return fmt.Errorf("permission set %q not found", nsid)
+}
+
+func parScopeForm(scope string) string {
+	form := url.Values{
+		"client_id":             {"http://localhost"},
+		"response_type":         {"code"},
+		"code_challenge":        {"E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"},
+		"code_challenge_method": {"S256"},
+		"state":                 {"state-1"},
+		"redirect_uri":          {"http://127.0.0.1/"},
+		"scope":                 {scope},
+	}
+	return form.Encode()
+}
+
+func postPar(t *testing.T, s *Server, scope string) (int, map[string]string) {
+	t.Helper()
+	proof := newTestDpopProof(t, s, http.MethodPost, "https://"+testHostname+"/oauth/par")
+	c, rec := newRequestContext(http.MethodPost, "/oauth/par", parScopeForm(scope), map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+		"DPoP":         proof,
+	})
+	if err := s.handleOauthPar(c); err != nil {
+		c.Error(err)
+	}
+	var body map[string]string
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	return rec.Code, body
+}
+
+func TestParRejectsMalformedScope(t *testing.T) {
+	s := newTestServer(t)
+	attachOauthProvider(t, s)
+	s.scopeResolver = stubResolver{valid: map[string]bool{}}
+
+	code, body := postPar(t, s, "atproto repo:not a nsid")
+	if code != 400 {
+		t.Fatalf("expected 400 for malformed scope, got %d (%v)", code, body)
+	}
+	if body["error"] != "invalid_scope" {
+		t.Fatalf("expected error invalid_scope, got %q", body["error"])
+	}
+}
+
+func TestParRejectsUnresolvableInclude(t *testing.T) {
+	s := newTestServer(t)
+	attachOauthProvider(t, s)
+	s.scopeResolver = stubResolver{valid: map[string]bool{"site.standard.authFull": true}}
+
+	code, body := postPar(t, s, "atproto include:earth.cirrus.check.invalidnonexistentpermissionset")
+	if code != 400 {
+		t.Fatalf("expected 400 for unresolvable include, got %d (%v)", code, body)
+	}
+	if body["error"] != "invalid_scope" {
+		t.Fatalf("expected error invalid_scope, got %q", body["error"])
+	}
+}
+
+func TestParAcceptsResolvableInclude(t *testing.T) {
+	s := newTestServer(t)
+	attachOauthProvider(t, s)
+	s.scopeResolver = stubResolver{valid: map[string]bool{"site.standard.authFull": true}}
+
+	code, body := postPar(t, s, "atproto include:site.standard.authFull")
+	if code != 201 {
+		t.Fatalf("expected 201 for resolvable include, got %d (%v)", code, body)
+	}
+}
+
+func TestParAcceptsLegacyScopes(t *testing.T) {
+	s := newTestServer(t)
+	attachOauthProvider(t, s)
+	// No resolver needed; legacy scopes contain no include.
+	s.scopeResolver = stubResolver{valid: map[string]bool{}}
+
+	code, body := postPar(t, s, "atproto transition:generic")
+	if code != 201 {
+		t.Fatalf("expected 201 for legacy scopes, got %d (%v)", code, body)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/haileyok/cocoon/oauth/constants"
 	"github.com/haileyok/cocoon/oauth/dpop"
 	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/haileyok/cocoon/oauth/scopes"
 	"github.com/haileyok/cocoon/plc"
 	"github.com/ipfs/go-cid"
 	"github.com/labstack/echo-contrib/echoprometheus"
@@ -82,6 +83,7 @@ type Server struct {
 	oauthProvider *provider.Provider
 	evtman        *events.EventManager
 	passport      *identity.Passport
+	scopeResolver scopes.PermissionSetResolver
 	fallbackProxy string
 
 	lastRequestCrawl time.Time
@@ -444,8 +446,9 @@ func New(args *Args) (*Server, error) {
 			BlockstoreVariant: args.BlockstoreVariant,
 			FallbackProxy:     args.FallbackProxy,
 		},
-		evtman:   events.NewEventManager(evtPersister),
-		passport: identity.NewPassport(h, identity.NewMemCache(10_000)),
+		evtman:        events.NewEventManager(evtPersister),
+		passport:      identity.NewPassport(h, identity.NewMemCache(10_000)),
+		scopeResolver: scopes.NewIndigoResolver(),
 
 		dbName:   args.DbName,
 		dbType:   dbType,


### PR DESCRIPTION
## What

First cut of atproto permissioned scopes (proposal 0011-auth-scopes). Adds a scope parser/model and PAR-time validation that rejects syntactically-invalid scopes and unresolvable `include:` permission sets with `invalid_scope`.

Addresses pdscheck OAuth finding 2 (PAR accepts a nonexistent `include:` permission set / malformed scopes).

## Changes

- `oauth/scopes/parser.go` (new): parses `resource[:positional][?params]` for `repo`, `rpc`, `blob`, `account`, `identity`, `include`, plus legacy `atproto` and `transition:*`. URL-decodes params, repeated params -> arrays, validates NSID syntax via `syntax.ParseNSID`, and rejects disallowed wildcard combinations (`repo` `action=*`, `rpc:*?aud=*`). Exposes `Scope.AllowsRepoWrite(collection, action)` for downstream enforcement.
- `oauth/scopes/resolver.go` (new): `PermissionSetResolver` interface + `IndigoResolver`, which resolves `include:<nsid>` via indigo's `lexicon.ResolveLexiconSchemaFile` (DNS TXT `_lexicon.<authority>` -> DID -> `com.atproto.lexicon.schema` record) and checks the `main` def is a `permission-set`. Small in-memory TTL cache (positive/negative).
- `server/scope_validation.go` (new): `validateRequestedScopes` parses the requested scope and resolves each `include:`; skipped when no resolver is configured.
- `server/handle_oauth_par.go` + `server/handle_oauth_authorize.go`: validate the requested scope after client auth, returning `400 invalid_scope` on failure (PAR endpoint + inline-PAR branch).
- `server/server.go`: wire a real `IndigoResolver` onto the server in `New()`.
- `go.mod`/`go.sum`: one new indirect dep (`github.com/rivo/uniseg`) pulled in by indigo's lexicon package.

## Resolution feasibility (verified)

Indigo fully supports `include:` resolution — no hand-rolled DNS/getRecord needed. Real clients sending `include:site.standard.authFull` resolve successfully (live), while a nonexistent NSID fails resolution and is rejected. Tests inject a stub resolver so they stay hermetic and offline.

## Tests

- `oauth/scopes/parser_test.go`: valid/invalid `repo`/`rpc`/`blob`/`account`/`identity`/`include`/legacy strings; `AllowsRepoWrite`.
- `server/scope_validation_test.go`: malformed scope -> 400 `invalid_scope`; unresolvable `include:` -> 400 `invalid_scope`; resolvable `include:` -> 201; legacy `atproto transition:generic` -> 201.

## Verification

`gofmt -l` clean, `go vet ./...` clean, `go test -race ./...` green.

## Notes

Granular scopes are open-form, so `scopes_supported` metadata is left as the legacy informational list. PR D (repo write enforcement) builds on this parser.