### PR TITLE
Fix panics during token validation

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -271,6 +271,11 @@ func (s *Server) handleOauthSessionMiddleware(next echo.HandlerFunc) echo.Handle
 			return helpers.InputError(e, nil)
 		}
 
+		if proof == nil {
+			logger.Error("No DPoP proof")
+			return helpers.InputError(e, nil)
+		}
+
 		var oauthToken provider.OauthToken
 		if err := s.db.Raw(ctx, "SELECT * FROM oauth_tokens WHERE token = ?", nil, accessToken).Scan(&oauthToken).Error; err != nil {
 			logger.Error("error finding access token in db", "error", err)

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -57,6 +57,9 @@ func (s *Server) handleLegacySessionMiddleware(next echo.HandlerFunc) echo.Handl
 
 		tokenstr := pts[1]
 		token, _, err := new(jwt.Parser).ParseUnverified(tokenstr, jwt.MapClaims{})
+		if err != nil {
+			return helpers.InvalidTokenError(e)
+		}
 		claims, ok := token.Claims.(jwt.MapClaims)
 		if !ok {
 			return helpers.InvalidTokenError(e)


### PR DESCRIPTION
I found a couple of places where Cocoon would panic if I sent it an incorrectly authenticated request. These changes catch those cases and make it return an error cleanly instead.
