### PR TITLE
fix(server): initialize genesis repo when creating an account with an existing did

### DIFF
--- a/server/handle_server_create_account.go
+++ b/server/handle_server_create_account.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bluesky-social/indigo/util"
 	"github.com/haileyok/cocoon/internal/helpers"
 	"github.com/haileyok/cocoon/models"
+	"github.com/ipfs/go-cid"
 	"github.com/labstack/echo/v4"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
@@ -219,40 +220,23 @@ func (s *Server) handleCreateAccount(e echo.Context) error {
 		}
 	}
 
-	if request.Did == nil || *request.Did == "" {
-		bs := s.getBlockstore(signupDid)
+	root, rev, err := s.initializeGenesisRepo(context.TODO(), urepo.Did, urepo.SigningKey)
+	if err != nil {
+		logger.Error("error initializing genesis repo", "error", err)
+		return helpers.ServerError(e, nil)
+	}
 
-		clk := syntax.NewTIDClock(0)
-		r := &atp.Repo{
-			DID:         syntax.DID(signupDid),
-			Clock:       clk,
-			MST:         mst.NewEmptyTree(),
-			RecordStore: bs,
-		}
+	s.evtman.AddEvent(context.TODO(), &events.XRPCStreamEvent{
+		RepoIdentity: &atproto.SyncSubscribeRepos_Identity{
+			Did:    urepo.Did,
+			Handle: to.StringPtr(request.Handle),
+			Seq:    time.Now().UnixMicro(), // TODO: no
+			Time:   time.Now().Format(util.ISO8601),
+		},
+	})
 
-		root, rev, err := commitRepo(context.TODO(), bs, r, urepo.SigningKey)
-		if err != nil {
-			logger.Error("error committing", "error", err)
-			return helpers.ServerError(e, nil)
-		}
-
-		if err := s.UpdateRepo(context.TODO(), urepo.Did, root, rev); err != nil {
-			logger.Error("error updating repo after commit", "error", err)
-			return helpers.ServerError(e, nil)
-		}
-
-		s.evtman.AddEvent(context.TODO(), &events.XRPCStreamEvent{
-			RepoIdentity: &atproto.SyncSubscribeRepos_Identity{
-				Did:    urepo.Did,
-				Handle: to.StringPtr(request.Handle),
-				Seq:    time.Now().UnixMicro(), // TODO: no
-				Time:   time.Now().Format(util.ISO8601),
-			},
-		})
-
-		if err := s.emitRepoSync(context.TODO(), urepo.Did, rev, root); err != nil {
-			logger.Error("error emitting repo sync event", "error", err)
-		}
+	if err := s.emitRepoSync(context.TODO(), urepo.Did, rev, root); err != nil {
+		logger.Error("error emitting repo sync event", "error", err)
 	}
 
 	sess, err := s.createSession(ctx, &urepo)
@@ -276,4 +260,29 @@ func (s *Server) handleCreateAccount(e echo.Context) error {
 		Handle:     request.Handle,
 		Did:        signupDid,
 	})
+}
+
+// initializeGenesisRepo commits an empty MST for did and records it as the
+// repo's current head.
+func (s *Server) initializeGenesisRepo(ctx context.Context, did string, signingKey []byte) (cid.Cid, string, error) {
+	bs := s.getBlockstore(did)
+
+	clk := syntax.NewTIDClock(0)
+	r := &atp.Repo{
+		DID:         syntax.DID(did),
+		Clock:       clk,
+		MST:         mst.NewEmptyTree(),
+		RecordStore: bs,
+	}
+
+	root, rev, err := commitRepo(ctx, bs, r, signingKey)
+	if err != nil {
+		return cid.Undef, "", fmt.Errorf("commit genesis repo: %w", err)
+	}
+
+	if err := s.UpdateRepo(ctx, did, root, rev); err != nil {
+		return cid.Undef, "", fmt.Errorf("update repo after genesis commit: %w", err)
+	}
+
+	return root, rev, nil
 }

--- a/server/handle_server_create_account_test.go
+++ b/server/handle_server_create_account_test.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/indigo/atproto/atcrypto"
+	"github.com/bluesky-social/indigo/events"
+	"github.com/haileyok/cocoon/identity"
+)
+
+// TestCreateAccountInitializesRepoForExistingDID asserts an account created
+// via the existing-DID flow gets a genesis repo commit and #identity/#sync
+// events, same as the flow where cocoon mints the DID itself.
+func TestCreateAccountInitializesRepoForExistingDID(t *testing.T) {
+	s := newTestServer(t)
+
+	persister, err := NewDbPersister(s.db.Client(), time.Hour)
+	if err != nil {
+		t.Fatalf("new persister: %v", err)
+	}
+	s.evtman = events.NewEventManager(persister)
+
+	k, err := atcrypto.GeneratePrivateKeyK256()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pub, err := k.PublicKey()
+	if err != nil {
+		t.Fatalf("derive public key: %v", err)
+	}
+
+	const did = "did:plc:aaaaaaaaaaaaaaaaaaaaaaaa"
+	const handle = "alice.pds.test"
+
+	cache := identity.NewMemCache(10)
+	if err := cache.PutDoc(did, &identity.DidDoc{
+		Id: did,
+		VerificationMethods: []identity.DidDocVerificationMethod{
+			{
+				Id:                 did + "#atproto",
+				Type:               "Multikey",
+				Controller:         did,
+				PublicKeyMultibase: pub.Multibase(),
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed passport cache: %v", err)
+	}
+	s.passport = identity.NewPassport(nil, cache)
+
+	tok := mintServiceAuthToken(t, k.Bytes(), did, s.config.Did, "com.atproto.server.createAccount", time.Now().Add(time.Minute))
+
+	body, err := json.Marshal(map[string]string{
+		"handle":   handle,
+		"email":    "alice@test.invalid",
+		"password": "correct-horse-battery-staple",
+		"did":      did,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	c, rec := newRequestContext(http.MethodPost, "/xrpc/com.atproto.server.createAccount", string(body), map[string]string{
+		"authorization": "Bearer " + tok,
+	})
+
+	if err := s.handleCreateAccount(c); err != nil {
+		t.Fatalf("handleCreateAccount: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	urepo, err := s.getRepoActorByDid(context.Background(), did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+	if urepo.Repo.Rev == "" {
+		t.Fatal("repo has no rev after account creation via the existing-DID flow")
+	}
+	if len(urepo.Repo.Root) == 0 {
+		t.Fatal("repo has no root after account creation via the existing-DID flow")
+	}
+
+	types := eventTypesFor(t, s, did)
+	for _, want := range []string{"identity", "sync"} {
+		if !contains(types, want) {
+			t.Fatalf("missing %q event after account creation; got %v", want, types)
+		}
+	}
+}


### PR DESCRIPTION
## What

A new account needs initialization with a genesis repo commit before you can write to it. This was correctly done when the PDS creates the account along with a brand new DID, and also when you imported an account from another PDS. However, if you created the DID for a new account yourself, then called `createAccount`, `rev`/`root` would stay `""`/`NULL` forever.

## Motivation

I want to do this as part of a flow where you create a fully self-custodial account on the client side and the only rotation key in the history is custodied by the user, never the PDS.

## How it works

The commit-and-record logic that used to run only inside `if request.Did == nil` is extracted into `initializeGenesisRepo` and now called unconditionally. This shouldn't affect `importRepo` which unconditionally overwrites `root`/`rev` from the uploaded CAR regardless of prior state, so an empty genesis commit doesn't conflict with a later import.

## Surface

- `server/handle_server_create_account.go`: new `initializeGenesisRepo(ctx, did, signingKey) (cid.Cid, string, error)`, `handleCreateAccount` calls it unconditionally instead of only when `request.Did == nil`.
- `server/handle_server_create_account_test.go`: new test.

## Tests

`TestCreateAccountInitializesRepoForExistingDID` creates an account via the existing-DID path and asserts `rev`/`root` are populated and both `#identity` and `#sync` events are recorded. Confirmed it catches the bug: temporarily restored the old `if request.Did == nil` gate, watched it fail, reverted.

`go vet ./...` and `go test -race ./...` pass; `gofmt -l .` is clean.


