### PR TITLE
feat(oauth): expand include: scopes to granular scopes at token issuance

### DIFF
--- a/oauth/scopes/resolver.go
+++ b/oauth/scopes/resolver.go
@@ -12,16 +12,17 @@ import (
 )
 
 // PermissionSetResolver resolves an `include:<nsid>` scope to its permission-set
-// lexicon. ResolvePermissionSet returns nil when the NSID resolves to a valid
-// permission-set record, or an error otherwise.
+// lexicon. ResolvePermissionSet returns the parsed permission-set when the NSID
+// resolves to a valid permission-set record, or an error otherwise.
 type PermissionSetResolver interface {
-	ResolvePermissionSet(ctx context.Context, nsid string) error
+	ResolvePermissionSet(ctx context.Context, nsid string) (*lexicon.SchemaPermissionSet, error)
 }
 
 // directory is the subset of indigo's identity.Directory used here.
 type directory = identity.Directory
 
 type cacheEntry struct {
+	ps      *lexicon.SchemaPermissionSet
 	err     error
 	expires time.Time
 }
@@ -55,53 +56,54 @@ func NewIndigoResolverWithDirectory(dir directory) *IndigoResolver {
 	}
 }
 
-func (r *IndigoResolver) ResolvePermissionSet(ctx context.Context, nsidStr string) error {
+func (r *IndigoResolver) ResolvePermissionSet(ctx context.Context, nsidStr string) (*lexicon.SchemaPermissionSet, error) {
 	if cached, ok := r.lookup(nsidStr); ok {
-		return cached
+		return cached.ps, cached.err
 	}
 
-	err := r.resolve(ctx, nsidStr)
-	r.store(nsidStr, err)
-	return err
+	ps, err := r.resolve(ctx, nsidStr)
+	r.store(nsidStr, ps, err)
+	return ps, err
 }
 
-func (r *IndigoResolver) resolve(ctx context.Context, nsidStr string) error {
+func (r *IndigoResolver) resolve(ctx context.Context, nsidStr string) (*lexicon.SchemaPermissionSet, error) {
 	nsid, err := syntax.ParseNSID(nsidStr)
 	if err != nil {
-		return fmt.Errorf("invalid nsid %q: %w", nsidStr, err)
+		return nil, fmt.Errorf("invalid nsid %q: %w", nsidStr, err)
 	}
 
 	sf, err := lexicon.ResolveLexiconSchemaFile(ctx, r.dir, nsid)
 	if err != nil {
-		return fmt.Errorf("could not resolve permission set %q: %w", nsidStr, err)
+		return nil, fmt.Errorf("could not resolve permission set %q: %w", nsidStr, err)
 	}
 
 	main, ok := sf.Defs["main"]
 	if !ok {
-		return fmt.Errorf("lexicon %q has no main definition", nsidStr)
+		return nil, fmt.Errorf("lexicon %q has no main definition", nsidStr)
 	}
-	if _, ok := main.Inner.(lexicon.SchemaPermissionSet); !ok {
-		return fmt.Errorf("lexicon %q main definition is not a permission-set", nsidStr)
+	ps, ok := main.Inner.(lexicon.SchemaPermissionSet)
+	if !ok {
+		return nil, fmt.Errorf("lexicon %q main definition is not a permission-set", nsidStr)
 	}
-	return nil
+	return &ps, nil
 }
 
-func (r *IndigoResolver) lookup(nsid string) (error, bool) {
+func (r *IndigoResolver) lookup(nsid string) (cacheEntry, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	entry, ok := r.cache[nsid]
 	if !ok || time.Now().After(entry.expires) {
-		return nil, false
+		return cacheEntry{}, false
 	}
-	return entry.err, true
+	return entry, true
 }
 
-func (r *IndigoResolver) store(nsid string, err error) {
+func (r *IndigoResolver) store(nsid string, ps *lexicon.SchemaPermissionSet, err error) {
 	ttl := r.posTTL
 	if err != nil {
 		ttl = r.negTTL
 	}
 	r.mu.Lock()
-	r.cache[nsid] = cacheEntry{err: err, expires: time.Now().Add(ttl)}
+	r.cache[nsid] = cacheEntry{ps: ps, err: err, expires: time.Now().Add(ttl)}
 	r.mu.Unlock()
 }

--- a/server/handle_oauth_token.go
+++ b/server/handle_oauth_token.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -16,6 +18,7 @@ import (
 	"github.com/haileyok/cocoon/oauth/constants"
 	"github.com/haileyok/cocoon/oauth/dpop"
 	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/haileyok/cocoon/oauth/scopes"
 	"github.com/labstack/echo/v4"
 )
 
@@ -123,8 +126,11 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 
 		refreshToken := oauth.GenerateRefreshToken()
 
+		expandedScope := s.expandScopes(ctx, authReq.Parameters.Scope)
+		authReq.Parameters.Scope = expandedScope
+
 		accessClaims := jwt.MapClaims{
-			"scope":     authReq.Parameters.Scope,
+			"scope":     expandedScope,
 			"aud":       s.config.Did,
 			"sub":       repo.Repo.Did,
 			"iat":       now.Unix(),
@@ -172,7 +178,7 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 			AccessToken:  accessString,
 			RefreshToken: refreshToken,
 			TokenType:    tokenType,
-			Scope:        authReq.Parameters.Scope,
+			Scope:        expandedScope,
 			ExpiresIn:    int64(eat.Sub(time.Now()).Seconds()),
 			Sub:          repo.Repo.Did,
 		})
@@ -222,8 +228,11 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 		now := time.Now()
 		eat := now.Add(constants.TokenMaxAge)
 
+		expandedScope := s.expandScopes(ctx, oauthToken.Parameters.Scope)
+		oauthToken.Parameters.Scope = expandedScope
+
 		accessClaims := jwt.MapClaims{
-			"scope":     oauthToken.Parameters.Scope,
+			"scope":     expandedScope,
 			"aud":       s.config.Did,
 			"sub":       oauthToken.Sub,
 			"iat":       now.Unix(),
@@ -243,7 +252,7 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 			return err
 		}
 
-		if err := s.db.Exec(ctx, "UPDATE oauth_tokens SET token = ?, refresh_token = ?, expires_at = ?, updated_at = ? WHERE refresh_token = ?", nil, accessString, nextRefreshToken, eat, now, *req.RefreshToken).Error; err != nil {
+		if err := s.db.Exec(ctx, "UPDATE oauth_tokens SET token = ?, refresh_token = ?, expires_at = ?, updated_at = ?, parameters = ? WHERE refresh_token = ?", nil, accessString, nextRefreshToken, eat, now, oauthToken.Parameters, *req.RefreshToken).Error; err != nil {
 			logger.Error("error updating token", "error", err)
 			return helpers.ServerError(e, nil)
 		}
@@ -258,13 +267,61 @@ func (s *Server) handleOauthToken(e echo.Context) error {
 			AccessToken:  accessString,
 			RefreshToken: nextRefreshToken,
 			TokenType:    tokenType,
-			Scope:        oauthToken.Parameters.Scope,
+			Scope:        expandedScope,
 			ExpiresIn:    int64(eat.Sub(time.Now()).Seconds()),
 			Sub:          oauthToken.Sub,
 		})
 	}
 
 	return helpers.InputError(e, to.StringPtr(fmt.Sprintf(`grant type "%s" is not supported`, req.GrantType)))
+}
+
+// expandScopes parses a raw scope string, resolves any include: scopes via
+// the permission-set resolver, and appends the expanded granular scopes
+// alongside the originals. If the resolver is nil or resolution fails, the
+// original scope string is returned unchanged.
+func (s *Server) expandScopes(ctx context.Context, rawScope string) string {
+	if s.scopeResolver == nil {
+		return rawScope
+	}
+	parsed, err := scopes.ParseList(rawScope)
+	if err != nil {
+		return rawScope
+	}
+	var out []string
+	for _, sc := range parsed {
+		out = append(out, sc.Raw)
+		if sc.Resource != scopes.ResourceInclude {
+			continue
+		}
+		ps, err := s.scopeResolver.ResolvePermissionSet(ctx, sc.Nsid)
+		if err != nil || ps == nil {
+			continue
+		}
+		for _, perm := range ps.Permissions {
+			switch perm.Resource {
+			case "repo":
+				for _, coll := range perm.Collection {
+					if len(perm.Action) > 0 {
+						for _, act := range perm.Action {
+							out = append(out, fmt.Sprintf("repo:%s?action=%s", coll, act))
+						}
+					} else {
+						out = append(out, fmt.Sprintf("repo:%s", coll))
+					}
+				}
+			case "rpc":
+				for _, lxm := range perm.LXM {
+					aud := perm.Audience
+					if aud == "" {
+						aud = "*"
+					}
+					out = append(out, fmt.Sprintf("rpc:%s?aud=%s", lxm, aud))
+				}
+			}
+		}
+	}
+	return strings.Join(out, " ")
 }
 
 // verifyPKCE checks a PKCE code_verifier against the stored code_challenge for

--- a/server/scope_validation.go
+++ b/server/scope_validation.go
@@ -25,7 +25,7 @@ func (s *Server) validateRequestedScopes(ctx context.Context, scope string) erro
 		if s.scopeResolver == nil {
 			continue
 		}
-		if err := s.scopeResolver.ResolvePermissionSet(ctx, sc.Nsid); err != nil {
+		if _, err := s.scopeResolver.ResolvePermissionSet(ctx, sc.Nsid); err != nil {
 			return fmt.Errorf("include scope %q could not be resolved: %w", sc.Raw, err)
 		}
 	}

--- a/server/scope_validation_test.go
+++ b/server/scope_validation_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/lexicon"
 )
 
 // stubResolver is a hermetic PermissionSetResolver: only NSIDs in valid resolve.
@@ -14,11 +16,11 @@ type stubResolver struct {
 	valid map[string]bool
 }
 
-func (r stubResolver) ResolvePermissionSet(ctx context.Context, nsid string) error {
+func (r stubResolver) ResolvePermissionSet(ctx context.Context, nsid string) (*lexicon.SchemaPermissionSet, error) {
 	if r.valid[nsid] {
-		return nil
+		return &lexicon.SchemaPermissionSet{}, nil
 	}
-	return fmt.Errorf("permission set %q not found", nsid)
+	return nil, fmt.Errorf("permission set %q not found", nsid)
 }
 
 func parScopeForm(scope string) string {


### PR DESCRIPTION
Cocoon validated include: permission-set scopes at PAR time (resolving the lexicon to check it exists) but never expanded them to granular repo:/rpc:scopes. Tokens were issued with the raw include: scope string, and the DB record stored the same unexpanded string. 
I encountered it when trying to publish an article with Leaflet, it couldn't find repo:site.standard.document?action=create in the token's scopes, and cocoon's hasRepoScope couldn't find it either.