### PR TITLE
fix(oauth): tolerate client assertion clock skew

### DIFF
--- a/oauth/constants/constants.go
+++ b/oauth/constants/constants.go
@@ -17,7 +17,8 @@ const (
 	ClientAssertionTypeJwtBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 	ParExpiresIn                 = 5 * time.Minute
 
-	ClientAssertionMaxAge = 1 * time.Minute
+	ClientAssertionMaxAge    = 1 * time.Minute
+	ClientAssertionClockSkew = 30 * time.Second
 
 	DeviceIdPrefix      = "dev-"
 	DeviceIdBytesLength = 16

--- a/oauth/provider/client_auth.go
+++ b/oauth/provider/client_auth.go
@@ -83,7 +83,11 @@ func (p *Provider) Authenticate(_ context.Context, req AuthenticateClientRequest
 			return nil, fmt.Errorf("failed to extract raw key: %w", err)
 		}
 
-		token, err = jwt.Parse(*req.ClientAssertion, func(token *jwt.Token) (any, error) {
+		// Skip MapClaims.Valid's zero-tolerance time checks and enforce them
+		// explicitly below with a small bounded allowance for clock skew between
+		// the OAuth client and authorization server. Signature and algorithm
+		// verification still happen here.
+		token, err = (&jwt.Parser{SkipClaimsValidation: true}).Parse(*req.ClientAssertion, func(token *jwt.Token) (any, error) {
 			if token.Method.Alg() != jwt.SigningMethodES256.Alg() {
 				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 			}
@@ -118,9 +122,20 @@ func (p *Provider) Authenticate(_ context.Context, req AuthenticateClientRequest
 			return nil, errors.New(`invalid client_assertion jwt: "iat" is missing`)
 		}
 
+		now := time.Now()
 		iatTime := time.Unix(int64(iat), 0)
-		if time.Since(iatTime) > constants.ClientAssertionMaxAge {
+		if iatTime.After(now.Add(constants.ClientAssertionClockSkew)) {
+			return nil, errors.New("client_assertion jwt issued too far in the future")
+		}
+		if now.Sub(iatTime) > constants.ClientAssertionMaxAge {
 			return nil, errors.New("client_assertion jwt too old")
+		}
+
+		if nbf, ok := claims["nbf"].(float64); ok && time.Unix(int64(nbf), 0).After(now.Add(constants.ClientAssertionClockSkew)) {
+			return nil, errors.New("client_assertion jwt is not valid yet")
+		}
+		if exp, ok := claims["exp"].(float64); ok && time.Unix(int64(exp), 0).Before(now.Add(-constants.ClientAssertionClockSkew)) {
+			return nil, errors.New("client_assertion jwt is expired")
 		}
 
 		jti, _ := claims["jti"].(string)

--- a/server/handle_oauth_par_test.go
+++ b/server/handle_oauth_par_test.go
@@ -2,10 +2,19 @@ package server
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/json"
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/haileyok/cocoon/oauth/client"
+	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/lestrrat-go/jwx/v2/jwk"
 )
 
 func parForm(redirectURI string) string {
@@ -85,5 +94,83 @@ func TestHandleOauthParAcceptsRegisteredRedirectURI(t *testing.T) {
 	}
 	if resp.RequestURI == "" {
 		t.Fatalf("expected a request_uri in response, got empty")
+	}
+}
+
+// TestClientAssertionClockSkew verifies that PAR client authentication tolerates
+// normal clock skew without accepting assertions that are materially future-dated.
+func TestClientAssertionClockSkew(t *testing.T) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := jwk.FromRaw(&privateKey.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := key.Set(jwk.KeyIDKey, "test-key"); err != nil {
+		t.Fatal(err)
+	}
+	keys := jwk.NewSet()
+	if err := keys.AddKey(key); err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		clientID = "https://client.example/metadata.json"
+		audience = "https://" + testHostname
+	)
+	s := newTestServer(t)
+	attachOauthProvider(t, s)
+	p := s.oauthProvider
+	cl := &client.Client{
+		Metadata: &client.Metadata{
+			ClientID:                clientID,
+			TokenEndpointAuthMethod: "private_key_jwt",
+		},
+		JWKS: keys,
+	}
+
+	sign := func(t *testing.T, issuedAt time.Time) string {
+		t.Helper()
+		token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
+			"iss": clientID,
+			"sub": clientID,
+			"aud": audience,
+			"jti": "test-jti",
+			"iat": issuedAt.Unix(),
+		})
+		token.Header["kid"] = "test-key"
+		raw, err := token.SignedString(privateKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return raw
+	}
+
+	assertionType := "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+	for _, tt := range []struct {
+		name      string
+		issuedAt  time.Time
+		wantError bool
+	}{
+		{name: "small positive clock skew", issuedAt: time.Now().Add(10 * time.Second)},
+		{name: "excessive positive clock skew", issuedAt: time.Now().Add(time.Minute), wantError: true},
+		{name: "assertion too old", issuedAt: time.Now().Add(-2 * time.Minute), wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assertion := sign(t, tt.issuedAt)
+			_, err := p.Authenticate(t.Context(), provider.AuthenticateClientRequestBase{
+				ClientID:            clientID,
+				ClientAssertionType: &assertionType,
+				ClientAssertion:     &assertion,
+			}, cl)
+			if tt.wantError && err == nil {
+				t.Fatal("expected authentication error")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("unexpected authentication error: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- allow up to 30 seconds of clock skew when validating private-key JWT client assertions
- retain explicit rejection of assertions that are too old, materially future-dated, not yet valid, or expired
- add regression coverage for accepted and rejected clock-skew cases

## Context

Attie login against Cocoon failed during PAR with `InvalidRequest`, while the same client metadata and request worked against other ATProto authorization servers. Cocoon delegated temporal validation to `jwt.MapClaims.Valid`, which has zero clock tolerance and rejects an `iat` even slightly ahead of the PDS clock. This is a known interoperability failure for OAuth clients and authorization servers on separate hosts.

## Verification

- `go test ./...`
- `go vet ./...`