### PR TITLE
fix: Handle panic when there's both missing DPoP header and missing dpop_jkt for PAR request

### DIFF
--- a/server/handle_oauth_par.go
+++ b/server/handle_oauth_par.go
@@ -76,7 +76,25 @@ func (s *Server) handleOauthPar(e echo.Context) error {
 
 	if parRequest.DpopJkt == nil {
 		if client.Metadata.DpopBoundAccessTokens {
-			parRequest.DpopJkt = to.StringPtr(dpopProof.JKT)
+			if dpopProof != nil {
+				parRequest.DpopJkt = to.StringPtr(dpopProof.JKT)
+			} else {
+				// RFC 9449§10.1 when PAR and DPoP are used together, the
+				// client must provide either a dpop_jkt parameter or a DPoP proof
+				// header.
+				// n.b. The reference PDS implementation is lenient to this
+				// behaviour currently but it's stated as deprecated.
+				// https://atproto.com/blog/oauth-improvements#deprecation-notice
+				nonce := s.oauthProvider.NextNonce()
+				if nonce != "" {
+					e.Response().Header().Set("DPoP-Nonce", nonce)
+					e.Response().Header().Add("access-control-expose-headers", "DPoP-Nonce")
+				}
+				logger.Error("no dpop_jkt and no dpop proof: use_dpop_nonce")
+				return e.JSON(400, map[string]string{
+					"error": "use_dpop_nonce",
+				})
+			}
 		}
 	} else {
 		if !client.Metadata.DpopBoundAccessTokens {
@@ -85,7 +103,7 @@ func (s *Server) handleOauthPar(e echo.Context) error {
 			return helpers.InputError(e, &msg)
 		}
 
-		if dpopProof.JKT != *parRequest.DpopJkt {
+		if dpopProof != nil && dpopProof.JKT != *parRequest.DpopJkt {
 			msg := "supplied dpop jkt does not match header dpop jkt"
 			logger.Error(msg)
 			return helpers.InputError(e, &msg)

--- a/server/handle_oauth_par_test.go
+++ b/server/handle_oauth_par_test.go
@@ -174,3 +174,38 @@ func TestClientAssertionClockSkew(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleOauthParWithoutDpopProof verifies that a PAR request without a
+// DPoP proof header or dpop_jkt parameter is rejected with use_dpop_nonce,
+// not a panic.
+func TestHandleOauthParWithoutDpopProof(t *testing.T) {
+	s := newTestServer(t)
+	attachOauthProvider(t, s)
+
+	body := parForm("http://127.0.0.1/")
+	c, rec := newRequestContext(http.MethodPost, "/oauth/par", body, map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	})
+
+	if err := s.handleOauthPar(c); err != nil {
+		c.Error(err)
+	}
+
+	if rec.Code != 400 {
+		t.Fatalf("expected 400 for PAR without DPoP, got %d (body %s)", rec.Code, rec.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if resp["error"] != "use_dpop_nonce" {
+		t.Fatalf("expected error use_dpop_nonce, got %q", resp["error"])
+	}
+	if rec.Header().Get("DPoP-Nonce") == "" {
+		t.Fatal("expected DPoP-Nonce header in response")
+	}
+	if n := countAuthRequests(t, s); n != 0 {
+		t.Fatalf("expected no authorization request rows, got %d", n)
+	}
+}


### PR DESCRIPTION
When a PAR request arrives with neither a DPoP header nor dpop_jkt parameter (as I discovered from [trezy.pet](https://trezy.pet/)), the server dereferences a nil pointer and panics. 

Note that the Atproto reference PDS implementation [does support](https://github.com/bluesky-social/atproto/blob/54ea1c6275e6fb90649cf2839f532603449e00ab/packages/oauth/oauth-provider/src/oauth-provider.ts#L505) a request with neither provided, but it's listed under [deprecation notice](https://atproto.com/blog/oauth-improvements#deprecation-notice).

Per RFC 9449 section 10.1, the client must provide one of these two mechanisms. I decided to return use_dpop_nonce to bootstrap the DPoP flow so the client retries with a proof + nonce, rather than crashing or going off spec.