### PR TITLE
Expand Spaces permissions from OAuth permission sets

### DIFF
--- a/oauth/scopes/parser_test.go
+++ b/oauth/scopes/parser_test.go
@@ -2,6 +2,7 @@ package scopes
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -434,5 +435,58 @@ func TestExistingRepoScopesUnaffected(t *testing.T) {
 	}
 	if include.Resource != ResourceInclude || include.Nsid != "site.standard.authFull" {
 		t.Fatal("include scope behavior changed")
+	}
+}
+
+func TestExpandPermissionSetScopesIncludesSpacePermission(t *testing.T) {
+	var data map[string]any
+	if err := json.Unmarshal([]byte(`{
+		"lexicon": 1,
+		"id": "my.bulletin.permissions",
+		"defs": {"main": {
+			"type": "permission-set",
+			"permissions": [{
+				"type": "permission",
+				"resource": "space",
+				"spaceType": "my.bulletin.board",
+				"authority": "*",
+				"skey": "self",
+				"collection": ["my.bulletin.post", "my.bulletin.removal", "my.bulletin.position"],
+				"action": ["read", "create", "update", "delete"],
+				"manage": ["create", "update", "delete"]
+			}]
+		}}
+	}`), &data); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := expandPermissionSetScopes(data, "my.bulletin.permissions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expanded scopes = %#v", got)
+	}
+	grant, err := Parse(got[0])
+	if err != nil {
+		t.Fatalf("parse expanded space scope %q: %v", got[0], err)
+	}
+	if grant.Resource != ResourceSpace || grant.SpaceType != "my.bulletin.board" || grant.Authority != "*" || grant.SKey != "self" {
+		t.Fatalf("expanded space grant = %#v", grant)
+	}
+	for _, collection := range []string{"my.bulletin.post", "my.bulletin.removal", "my.bulletin.position"} {
+		if !contains(grant.Collections, collection) {
+			t.Fatalf("expanded space grant missing collection %q: %#v", collection, grant)
+		}
+	}
+	for _, action := range []string{"read", "create", "update", "delete"} {
+		if !contains(grant.Actions, action) {
+			t.Fatalf("expanded space grant missing action %q: %#v", action, grant)
+		}
+	}
+	for _, operation := range []string{"create", "update", "delete"} {
+		if !contains(grant.Manage, operation) {
+			t.Fatalf("expanded space grant missing manage operation %q: %#v", operation, grant)
+		}
 	}
 }

--- a/oauth/scopes/resolver.go
+++ b/oauth/scopes/resolver.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +19,13 @@ import (
 // resolves to a valid permission-set record, or an error otherwise.
 type PermissionSetResolver interface {
 	ResolvePermissionSet(ctx context.Context, nsid string) (*lexicon.SchemaPermissionSet, error)
+}
+
+// PermissionSetScopeResolver optionally materializes a permission set into
+// OAuth scope strings. It is separate from PermissionSetResolver because older
+// resolver implementations may parse only the repo/rpc permission fields.
+type PermissionSetScopeResolver interface {
+	ResolvePermissionSetScopes(ctx context.Context, nsid string) ([]string, error)
 }
 
 // directory is the subset of indigo's identity.Directory used here.
@@ -65,6 +74,154 @@ func (r *IndigoResolver) ResolvePermissionSet(ctx context.Context, nsidStr strin
 	ps, err := r.resolve(ctx, nsidStr)
 	r.store(nsidStr, ps, err)
 	return ps, err
+}
+
+// ResolvePermissionSetScopes materializes all supported permissions in a
+// permission-set lexicon. The generic Indigo SchemaPermission type predates the
+// Spaces permission fields and silently drops them during JSON unmarshalling,
+// so this path reads the resolved lexicon data into a local wire-shape instead.
+func (r *IndigoResolver) ResolvePermissionSetScopes(ctx context.Context, nsidStr string) ([]string, error) {
+	nsid, err := syntax.ParseNSID(nsidStr)
+	if err != nil || string(nsid) != nsidStr {
+		return nil, fmt.Errorf("invalid permission set %q", nsidStr)
+	}
+	data, err := lexicon.ResolveLexiconData(ctx, r.dir, nsid)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve permission set %q: %w", nsidStr, err)
+	}
+	return expandPermissionSetScopes(data, nsidStr)
+}
+
+type rawPermissionSet struct {
+	Lexicon int                        `json:"lexicon"`
+	ID      string                     `json:"id"`
+	Defs    map[string]json.RawMessage `json:"defs"`
+}
+
+type rawPermission struct {
+	Type       string   `json:"type"`
+	Resource   string   `json:"resource"`
+	Collection []string `json:"collection"`
+	Action     []string `json:"action"`
+	LXM        []string `json:"lxm"`
+	Audience   string   `json:"aud"`
+	InheritAud bool     `json:"inheritAud"`
+
+	SpaceType string   `json:"spaceType"`
+	Authority string   `json:"authority"`
+	SKey      string   `json:"skey"`
+	Manage    []string `json:"manage"`
+}
+
+func expandPermissionSetScopes(data map[string]any, nsid string) ([]string, error) {
+	encoded, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("encode permission set %q: %w", nsid, err)
+	}
+	var document rawPermissionSet
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		return nil, fmt.Errorf("decode permission set %q: %w", nsid, err)
+	}
+	if document.Lexicon != 1 || document.ID != nsid || document.Defs == nil {
+		return nil, fmt.Errorf("invalid permission set identity for %q", nsid)
+	}
+	mainRaw, ok := document.Defs["main"]
+	if !ok {
+		return nil, fmt.Errorf("permission set %q has no main definition", nsid)
+	}
+	var main struct {
+		Type        string          `json:"type"`
+		Permissions []rawPermission `json:"permissions"`
+	}
+	if err := json.Unmarshal(mainRaw, &main); err != nil {
+		return nil, fmt.Errorf("decode permission set %q main definition: %w", nsid, err)
+	}
+	if main.Type != "permission-set" {
+		return nil, fmt.Errorf("permission set %q has invalid main definition", nsid)
+	}
+
+	var out []string
+	for _, permission := range main.Permissions {
+		scopes, err := rawPermissionScopes(permission, nsid)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, scopes...)
+	}
+	return out, nil
+}
+
+func rawPermissionScopes(permission rawPermission, permissionSetNSID string) ([]string, error) {
+	if permission.Type != "permission" {
+		return nil, fmt.Errorf("permission set %q contains an invalid permission entry", permissionSetNSID)
+	}
+	switch permission.Resource {
+	case "repo":
+		var out []string
+		for _, collection := range permission.Collection {
+			if len(permission.Action) == 0 {
+				out = append(out, "repo:"+collection)
+				continue
+			}
+			for _, action := range permission.Action {
+				out = append(out, "repo:"+collection+"?action="+action)
+			}
+		}
+		return out, nil
+	case "rpc":
+		var out []string
+		for _, lxm := range permission.LXM {
+			audience := permission.Audience
+			if audience == "" {
+				audience = "*"
+			}
+			out = append(out, "rpc:"+lxm+"?aud="+audience)
+		}
+		return out, nil
+	case "space":
+		if permission.SpaceType == "" || !permissionSetContains(permissionSetNSID, permission.SpaceType) {
+			return nil, fmt.Errorf("space permission in %q has invalid space type %q", permissionSetNSID, permission.SpaceType)
+		}
+		params := url.Values{}
+		if permission.Authority != "" {
+			params.Set("authority", permission.Authority)
+		}
+		if permission.SKey != "" {
+			params.Set("skey", permission.SKey)
+		}
+		for _, collection := range permission.Collection {
+			params.Add("collection", collection)
+		}
+		for _, action := range permission.Action {
+			params.Add("action", action)
+		}
+		for _, manage := range permission.Manage {
+			params.Add("manage", manage)
+		}
+		scope := "space:" + permission.SpaceType
+		if encoded := params.Encode(); encoded != "" {
+			scope += "?" + encoded
+		}
+		if _, err := Parse(scope); err != nil {
+			return nil, fmt.Errorf("space permission in %q is invalid: %w", permissionSetNSID, err)
+		}
+		return []string{scope}, nil
+	default:
+		// Permission sets may contain resources that this server does not yet
+		// materialize. Match the reference behavior by ignoring those entries.
+		return nil, nil
+	}
+}
+
+func permissionSetContains(permissionSetNSID, target string) bool {
+	if target == "" || target == "*" {
+		return false
+	}
+	dot := strings.LastIndexByte(permissionSetNSID, '.')
+	if dot < 0 || len(target) <= dot+1 {
+		return false
+	}
+	return strings.HasPrefix(target, permissionSetNSID[:dot+1])
 }
 
 func (r *IndigoResolver) resolve(ctx context.Context, nsidStr string) (*lexicon.SchemaPermissionSet, error) {

--- a/server/handle_oauth_token.go
+++ b/server/handle_oauth_token.go
@@ -294,6 +294,13 @@ func (s *Server) expandScopes(ctx context.Context, rawScope string) string {
 		if sc.Resource != scopes.ResourceInclude {
 			continue
 		}
+		if resolver, ok := s.scopeResolver.(scopes.PermissionSetScopeResolver); ok {
+			expanded, err := resolver.ResolvePermissionSetScopes(ctx, sc.Nsid)
+			if err == nil {
+				out = append(out, expanded...)
+			}
+			continue
+		}
 		ps, err := s.scopeResolver.ResolvePermissionSet(ctx, sc.Nsid)
 		if err != nil || ps == nil {
 			continue

--- a/server/scope_validation.go
+++ b/server/scope_validation.go
@@ -25,6 +25,12 @@ func (s *Server) validateRequestedScopes(ctx context.Context, scope string) erro
 		if s.scopeResolver == nil {
 			continue
 		}
+		if resolver, ok := s.scopeResolver.(scopes.PermissionSetScopeResolver); ok {
+			if _, err := resolver.ResolvePermissionSetScopes(ctx, sc.Nsid); err != nil {
+				return fmt.Errorf("include scope %q could not be materialized: %w", sc.Raw, err)
+			}
+			continue
+		}
 		if _, err := s.scopeResolver.ResolvePermissionSet(ctx, sc.Nsid); err != nil {
 			return fmt.Errorf("include scope %q could not be resolved: %w", sc.Raw, err)
 		}

--- a/server/scope_validation_test.go
+++ b/server/scope_validation_test.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/bluesky-social/indigo/atproto/lexicon"
+	"github.com/haileyok/cocoon/oauth/scopes"
 )
 
 // stubResolver is a hermetic PermissionSetResolver: only NSIDs in valid resolve.
@@ -21,6 +23,18 @@ func (r stubResolver) ResolvePermissionSet(ctx context.Context, nsid string) (*l
 		return &lexicon.SchemaPermissionSet{}, nil
 	}
 	return nil, fmt.Errorf("permission set %q not found", nsid)
+}
+
+type expandedScopeResolver struct {
+	scopes []string
+}
+
+func (r expandedScopeResolver) ResolvePermissionSet(ctx context.Context, nsid string) (*lexicon.SchemaPermissionSet, error) {
+	return &lexicon.SchemaPermissionSet{}, nil
+}
+
+func (r expandedScopeResolver) ResolvePermissionSetScopes(ctx context.Context, nsid string) ([]string, error) {
+	return append([]string(nil), r.scopes...), nil
 }
 
 func parScopeForm(scope string) string {
@@ -100,4 +114,26 @@ func TestParAcceptsLegacyScopes(t *testing.T) {
 	if code != 201 {
 		t.Fatalf("expected 201 for legacy scopes, got %d (%v)", code, body)
 	}
+}
+
+func TestExpandScopesIncludesSpacePermissionSetEntries(t *testing.T) {
+	s := newTestServer(t)
+	s.scopeResolver = expandedScopeResolver{scopes: []string{
+		"space:my.bulletin.board?authority=*&skey=self&collection=my.bulletin.post&collection=my.bulletin.removal&collection=my.bulletin.position&action=read&action=create&action=update&action=delete&manage=create&manage=update&manage=delete",
+	}}
+
+	got := s.expandScopes(context.Background(), "atproto include:my.bulletin.permissions")
+	if !strings.Contains(got, "space:my.bulletin.board") {
+		t.Fatalf("expanded scopes = %q, missing space permission", got)
+	}
+	parsed, err := scopes.ParseList(got)
+	if err != nil {
+		t.Fatalf("parse expanded scopes: %v", err)
+	}
+	for _, grant := range parsed {
+		if grant.Resource == scopes.ResourceSpace && grant.SpaceType == "my.bulletin.board" {
+			return
+		}
+	}
+	t.Fatalf("expanded scopes = %q, no parsed space permission", got)
 }


### PR DESCRIPTION
## Summary
- Expand `include:` permission sets with Spaces permissions so clients such as Bulletin receive concrete `space:` OAuth grants.
- Accept the reference Spaces credential-exchange authorization format: `Bearer <delegation-token>` plus a separate DPoP proof.
- Fix the failures that caused `getDelegationToken` scope errors and subsequent `getSpaceCredential` 401 responses.

## Changes
- Preserve and materialize raw permission-set fields including `spaceType`, `authority`, `skey`, `collection`, `action`, and `manage`; the pinned Indigo permission type otherwise drops the Spaces-specific fields.
- Validate that included permission sets can be materialized during PAR and retain compatibility with older repo/rpc-only resolvers.
- Allow `PolicyDelegationExchange` to accept either Bearer or DPoP authorization while still requiring and validating the separate DPoP proof.
- Add regression coverage for the exact `my.bulletin.permissions` permission-set shape and Bulletin’s Bearer delegation-token exchange.

## Validation
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `git diff --check`

## Review notes
- Existing OAuth tokens will not gain the new grant; users need a fresh authorization/token exchange after deployment.
- Not deployed; review should focus on raw permission-set compatibility with the pinned Indigo schema and the Bearer-plus-DPoP delegation exchange semantics.