### PR TITLE
Accept nonce-bearing Space DPoP proofs

### DIFF
--- a/space/auth_test.go
+++ b/space/auth_test.go
@@ -225,6 +225,23 @@ func TestDPoPProofChecksAndReplay(t *testing.T) {
 	}
 }
 
+func TestDPoPProofAcceptsOptionalNonce(t *testing.T) {
+	signer := testP256Signer(t)
+	proof, err := CreateDpopProof(signer, CreateDpopProofOptions{
+		Htm: "POST", Htu: "https://host.example/xrpc/com.atproto.space.getSpaceCredential",
+		Nonce: "oauth-nonce", JTI: "dpop-with-nonce", Now: testClock(testAuthNow),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyDpopProof(context.Background(), proof, VerifyDpopProofOptions{
+		Htm: "POST", Htu: "https://host.example/xrpc/com.atproto.space.getSpaceCredential",
+		Now: testClock(testAuthNow),
+	}); err != nil {
+		t.Fatalf("nonce-bearing issuance proof rejected: %v", err)
+	}
+}
+
 func TestAtprotoES256KTokenAdapter(t *testing.T) {
 	key, err := atcrypto.GeneratePrivateKeyK256()
 	if err != nil {

--- a/space/dpop_auth.go
+++ b/space/dpop_auth.go
@@ -41,6 +41,7 @@ type CreateDpopProofOptions struct {
 	Credential        string
 	CredentialPresent bool
 	JTI               string
+	Nonce             string
 	Now               func() time.Time
 	Random            io.Reader
 }
@@ -101,6 +102,9 @@ func CreateDpopProof(signer DPoPSigner, opts CreateDpopProofOptions) (string, er
 		return "", fmt.Errorf("invalid DPoP public JWK: %w", err)
 	}
 	claims := dpopClaims{JTI: opts.JTI, HTM: method, HTU: normalized, IAT: opts.Now().Unix()}
+	if opts.Nonce != "" {
+		claims.Nonce = &opts.Nonce
+	}
 	if opts.CredentialPresent || opts.Credential != "" {
 		if opts.Credential == "" {
 			return "", errors.New("credential must not be empty")
@@ -144,7 +148,9 @@ type VerifyDpopProofOptions struct {
 }
 
 // VerifyDpopProof checks signature, method, normalized URL, age, embedded-key
-// thumbprint, and ath. Replay is consumed atomically after every other check.
+// thumbprint, ath, and the optional nonce claim's type. Replay is consumed
+// atomically after every other check. Space hosts may accept a nonce issued for
+// another DPoP-protected endpoint without requiring one of their own.
 func VerifyDpopProof(ctx context.Context, raw string, opts VerifyDpopProofOptions) (DpopProof, error) {
 	method := opts.Htm
 	if method == "" {
@@ -181,7 +187,7 @@ func VerifyDpopProof(ctx context.Context, raw string, opts VerifyDpopProofOption
 	if err != nil {
 		return DpopProof{}, authErr("BadDpopProof", "invalid DPoP header", err)
 	}
-	cm, err := strictObject(cb, map[string]bool{"jti": true, "htm": true, "htu": true, "iat": true, "ath": true})
+	cm, err := strictObject(cb, map[string]bool{"jti": true, "htm": true, "htu": true, "iat": true, "ath": true, "nonce": true})
 	if err != nil {
 		return DpopProof{}, authErr("BadDpopProof", "invalid DPoP claims", err)
 	}
@@ -223,6 +229,12 @@ func VerifyDpopProof(ctx context.Context, raw string, opts VerifyDpopProofOption
 	iat, err := requiredInt64(cm, "iat")
 	if err != nil || iat <= 0 {
 		return DpopProof{}, authErr("BadDpopProof", "DPoP iat is required", err)
+	}
+	if rawNonce, ok := cm["nonce"]; ok {
+		nonce, nonceErr := stringValue(rawNonce)
+		if nonceErr != nil || nonce == "" {
+			return DpopProof{}, authErr("BadDpopNonce", "invalid DPoP nonce", nonceErr)
+		}
 	}
 	if opts.Now == nil {
 		opts.Now = time.Now
@@ -378,11 +390,12 @@ type dpopHeader struct {
 	JWK json.RawMessage `json:"jwk"`
 }
 type dpopClaims struct {
-	JTI string  `json:"jti"`
-	HTM string  `json:"htm"`
-	HTU string  `json:"htu"`
-	Ath *string `json:"ath,omitempty"`
-	IAT int64   `json:"iat"`
+	JTI   string  `json:"jti"`
+	HTM   string  `json:"htm"`
+	HTU   string  `json:"htu"`
+	Ath   *string `json:"ath,omitempty"`
+	Nonce *string `json:"nonce,omitempty"`
+	IAT   int64   `json:"iat"`
 }
 type p256JWK struct {
 	Kty string `json:"kty"`


### PR DESCRIPTION
## Summary
- Fix PDSLS credential-exchange failures caused by nonce-bearing DPoP proofs.
- Accept the optional `nonce` claim used by `@atcute/oauth-crypto` while preserving Space DPoP validation.

## Changes
- Allow an optional nonce claim in Space DPoP proofs and validate that it is a non-empty string.
- Add nonce support to Cocoon’s proof helper for complete protocol/test coverage.
- Keep issuance proofs unbound to `ath`; Space credential issuance still rejects an `ath` claim.
- Add a regression test reproducing a nonce-bearing issuance proof.

## Validation
- `go test ./space -run TestDPoPProofAcceptsOptionalNonce -count=1`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `git diff --check`

## Review notes
- This is based on current `main`, which includes the Bearer delegation-token compatibility fix from PR #128.
- Not deployed; after deployment, retry PDSLS credential exchange with a fresh proof.