### PR TITLE
fix: require legacy refresh credentials and rotate atomically

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -49,6 +49,16 @@ func (db *DB) Begin(ctx context.Context) *gorm.DB {
 	return db.cli.WithContext(ctx).Begin()
 }
 
+// Transaction runs fn with a DB wrapper bound to one GORM transaction. Every
+// helper called on the callback value uses that transaction rather than the
+// root connection. The transaction commits when fn returns nil and rolls back
+// otherwise.
+func (db *DB) Transaction(ctx context.Context, fn func(*DB) error) error {
+	return db.cli.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return fn(NewDB(tx))
+	})
+}
+
 func (db *DB) Client() *gorm.DB {
 	return db.cli
 }

--- a/server/handle_server_refresh_session.go
+++ b/server/handle_server_refresh_session.go
@@ -1,6 +1,10 @@
 package server
 
 import (
+	"errors"
+	"time"
+
+	"github.com/haileyok/cocoon/internal/db"
 	"github.com/haileyok/cocoon/internal/helpers"
 	"github.com/haileyok/cocoon/models"
 	"github.com/labstack/echo/v4"
@@ -19,20 +23,33 @@ func (s *Server) handleRefreshSession(e echo.Context) error {
 	ctx := e.Request().Context()
 	logger := s.logger.With("name", "handleServerRefreshSession")
 
+	if e.Get("legacyRefresh") != true {
+		return helpers.InvalidTokenError(e)
+	}
 	token := e.Get("token").(string)
 	repo := e.Get("repo").(*models.RepoActor)
 
-	if err := s.db.Exec(ctx, "DELETE FROM refresh_tokens WHERE token = ?", nil, token).Error; err != nil {
-		logger.Error("error getting refresh token from db", "error", err)
-		return helpers.ServerError(e, nil)
+	invalidRefresh := errors.New("refresh token is no longer valid")
+	var sess *Session
+	err := s.db.Transaction(ctx, func(tx *db.DB) error {
+		// Consume once, including when concurrent requests both passed middleware.
+		result := tx.Exec(ctx, "DELETE FROM refresh_tokens WHERE token = ? AND did = ? AND expires_at > ?", nil, token, repo.Repo.Did, time.Now())
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return invalidRefresh
+		}
+		if err := tx.Exec(ctx, "DELETE FROM tokens WHERE refresh_token = ?", nil, token).Error; err != nil {
+			return err
+		}
+		var err error
+		sess, err = s.createSessionWithDB(ctx, tx, &repo.Repo)
+		return err
+	})
+	if errors.Is(err, invalidRefresh) {
+		return helpers.InvalidTokenError(e)
 	}
-
-	if err := s.db.Exec(ctx, "DELETE FROM tokens WHERE refresh_token = ?", nil, token).Error; err != nil {
-		logger.Error("error deleting access token from db", "error", err)
-		return helpers.ServerError(e, nil)
-	}
-
-	sess, err := s.createSession(ctx, &repo.Repo)
 	if err != nil {
 		logger.Error("error creating new session for refresh", "error", err)
 		return helpers.ServerError(e, nil)

--- a/server/handle_server_refresh_session_test.go
+++ b/server/handle_server_refresh_session_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -112,6 +113,52 @@ func TestRefreshSessionRejectsOtherCredentials(t *testing.T) {
 	}
 }
 
+func TestRefreshSessionBearerSchemeCase(t *testing.T) {
+	for _, scheme := range []string{"Bearer", "bearer", "BEARER"} {
+		t.Run(scheme, func(t *testing.T) {
+			s, session := setupRefreshTest(t)
+			if w := refreshRequest(s, scheme+" "+session.RefreshToken); w.Code != http.StatusOK {
+				t.Fatalf("valid refresh: %d %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestRefreshSessionRejectsServiceAuth(t *testing.T) {
+	s, session := setupRefreshTest(t)
+	var beforeAccess []models.Token
+	var beforeRefresh []models.RefreshToken
+	if err := s.db.Client().Find(&beforeAccess).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := s.db.Client().Find(&beforeRefresh).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(beforeAccess) != 1 || len(beforeRefresh) != 1 || beforeAccess[0].Token != session.AccessToken {
+		t.Fatal("expected original session in both credential tables")
+	}
+	repo, err := s.getRepoActorByDid(context.Background(), beforeAccess[0].Did)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := mintServiceAuthToken(t, repo.SigningKey, repo.Repo.Did, testDid,
+		"com.atproto.server.refreshSession", time.Now().Add(time.Minute))
+	if w := refreshRequest(s, "Bearer "+token); w.Code < 400 || w.Code >= 500 {
+		t.Fatalf("expected service-auth rejection, got %d", w.Code)
+	}
+	var afterAccess []models.Token
+	var afterRefresh []models.RefreshToken
+	if err := s.db.Client().Find(&afterAccess).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := s.db.Client().Find(&afterRefresh).Error; err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(beforeAccess, afterAccess) || !reflect.DeepEqual(beforeRefresh, afterRefresh) {
+		t.Fatal("service-auth rejection changed credential tables")
+	}
+}
+
 func TestRefreshSessionRotationAndReplay(t *testing.T) {
 	s, session := setupRefreshTest(t)
 	w := refreshRequest(s, "Bearer "+session.RefreshToken)
@@ -125,8 +172,8 @@ func TestRefreshSessionRotationAndReplay(t *testing.T) {
 	if next.AccessJwt == "" || next.RefreshJwt == "" || next.RefreshJwt == session.RefreshToken {
 		t.Fatal("missing or unchanged replacement credentials")
 	}
-	if w := refreshRequest(s, "Bearer "+session.RefreshToken); w.Code < 400 {
-		t.Fatal("consumed refresh token accepted")
+	if w := refreshRequest(s, "Bearer "+session.RefreshToken); w.Code < 400 || w.Code >= 500 {
+		t.Fatalf("expected consumed refresh token rejection, got %d", w.Code)
 	}
 	for _, tc := range []struct {
 		token string
@@ -136,7 +183,7 @@ func TestRefreshSessionRotationAndReplay(t *testing.T) {
 		r.Header.Set("Authorization", "Bearer "+tc.token)
 		w := httptest.NewRecorder()
 		s.echo.ServeHTTP(w, r)
-		if (tc.want == 200 && w.Code != 200) || (tc.want == 400 && w.Code < 400) {
+		if (tc.want == 200 && w.Code != 200) || (tc.want == 400 && (w.Code < 400 || w.Code >= 500)) {
 			t.Fatalf("access token status: %d", w.Code)
 		}
 	}
@@ -169,7 +216,7 @@ func TestRefreshSessionConcurrentConsumption(t *testing.T) {
 		go func() { results <- refreshRequest(s, "Bearer "+session.RefreshToken).Code }()
 	}
 	a, b := <-results, <-results
-	if !((a == 200 && b >= 400) || (b == 200 && a >= 400)) {
+	if !((a == 200 && b >= 400 && b < 500) || (b == 200 && a >= 400 && a < 500)) {
 		t.Fatalf("expected one success, got %d and %d", a, b)
 	}
 	var count int64

--- a/server/handle_server_refresh_session_test.go
+++ b/server/handle_server_refresh_session_test.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"context"
+	"crypto"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/haileyok/cocoon/models"
+	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/labstack/echo/v4"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+)
+
+const refreshSessionPath = "/xrpc/com.atproto.server.refreshSession"
+
+func TestRefreshSessionRejectsOAuthGrant(t *testing.T) {
+	s, session := setupRefreshTest(t)
+	attachOauthProvider(t, s)
+	proof := newTestDpopProof(t, s, http.MethodPost, "https://"+testHostname+refreshSessionPath, &session.AccessToken)
+	parsed, _, err := new(jwt.Parser).ParseUnverified(proof, jwt.MapClaims{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyJSON, err := json.Marshal(parsed.Header["jwk"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := jwk.ParseKey(keyJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	thumb, err := key.Thumbprint(crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jkt := base64.RawURLEncoding.EncodeToString(thumb)
+	var legacy models.Token
+	if err := s.db.Client().Where("token = ?", session.AccessToken).First(&legacy).Error; err != nil {
+		t.Fatal(err)
+	}
+	// OAuth resource authentication uses the token row and matching DPoP key.
+	grant := provider.OauthToken{
+		Token: session.AccessToken, Sub: legacy.Did, ClientId: "http://localhost",
+		RefreshToken: "oauth-refresh-test", ExpiresAt: time.Now().Add(time.Hour),
+		Parameters: provider.ParRequest{Scope: "atproto", DpopJkt: &jkt},
+	}
+	if err := s.db.Create(context.Background(), &grant, nil).Error; err != nil {
+		t.Fatal(err)
+	}
+	r := httptest.NewRequest(http.MethodPost, refreshSessionPath, nil)
+	r.Header.Set("Authorization", "DPoP "+grant.Token)
+	r.Header.Set("DPoP", proof)
+	w := httptest.NewRecorder()
+	s.echo.ServeHTTP(w, r)
+	if w.Code < 400 || w.Code >= 500 {
+		t.Fatalf("expected OAuth rejection, got %d", w.Code)
+	}
+	var count int64
+	if err := s.db.Client().Model(&models.RefreshToken{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("unexpected legacy credentials: %d", count)
+	}
+}
+
+func refreshRequest(s *Server, authorization string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(http.MethodPost, refreshSessionPath, nil)
+	r.Header.Set("Authorization", authorization)
+	w := httptest.NewRecorder()
+	s.echo.ServeHTTP(w, r)
+	return w
+}
+
+func setupRefreshTest(t *testing.T) (*Server, *Session) {
+	t.Helper()
+	s := newTestServer(t)
+	account := s.createTestAccount(t, "refresh.pds.test")
+	repo, err := s.getRepoActorByDid(context.Background(), account.Did)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := s.createSession(context.Background(), &repo.Repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.echo = echo.New()
+	s.echo.Validator = newTestValidator()
+	s.addRoutes()
+	return s, session
+}
+
+func TestRefreshSessionRejectsOtherCredentials(t *testing.T) {
+	s, session := setupRefreshTest(t)
+	for _, auth := range []string{"", "Bearer " + session.AccessToken, "DPoP " + session.AccessToken} {
+		// No OAuth provider is installed: refresh must reject DPoP before
+		// entering OAuth authentication, irrespective of the token/proof.
+		w := refreshRequest(s, auth)
+		if w.Code < 400 || w.Code >= 500 {
+			t.Fatalf("expected client error, got %d", w.Code)
+		}
+	}
+	if w := refreshRequest(s, "Bearer "+session.RefreshToken); w.Code != 200 {
+		t.Fatalf("valid refresh: %d %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRefreshSessionRotationAndReplay(t *testing.T) {
+	s, session := setupRefreshTest(t)
+	w := refreshRequest(s, "Bearer "+session.RefreshToken)
+	if w.Code != 200 {
+		t.Fatalf("refresh: %d %s", w.Code, w.Body.String())
+	}
+	var next ComAtprotoServerRefreshSessionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &next); err != nil {
+		t.Fatal(err)
+	}
+	if next.AccessJwt == "" || next.RefreshJwt == "" || next.RefreshJwt == session.RefreshToken {
+		t.Fatal("missing or unchanged replacement credentials")
+	}
+	if w := refreshRequest(s, "Bearer "+session.RefreshToken); w.Code < 400 {
+		t.Fatal("consumed refresh token accepted")
+	}
+	for _, tc := range []struct {
+		token string
+		want  int
+	}{{session.AccessToken, 400}, {next.AccessJwt, 200}} {
+		r := httptest.NewRequest(http.MethodGet, "/xrpc/com.atproto.server.getSession", nil)
+		r.Header.Set("Authorization", "Bearer "+tc.token)
+		w := httptest.NewRecorder()
+		s.echo.ServeHTTP(w, r)
+		if (tc.want == 200 && w.Code != 200) || (tc.want == 400 && w.Code < 400) {
+			t.Fatalf("access token status: %d", w.Code)
+		}
+	}
+	if w := refreshRequest(s, "Bearer "+next.RefreshJwt); w.Code != 200 {
+		t.Fatalf("next refresh: %d", w.Code)
+	}
+}
+
+func TestRefreshSessionConcurrentConsumption(t *testing.T) {
+	s, session := setupRefreshTest(t)
+	pool, err := s.db.Client().DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool.SetMaxOpenConns(1)
+	// Synchronize after authentication so both requests reach the handler
+	// with a token that existed when middleware validated it.
+	var ready sync.WaitGroup
+	ready.Add(2)
+	s.echo.POST(refreshSessionPath, s.handleRefreshSession, s.handleLegacySessionMiddleware, s.handleOauthSessionMiddleware,
+		func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				ready.Done()
+				ready.Wait()
+				return next(c)
+			}
+		})
+	results := make(chan int, 2)
+	for range 2 {
+		go func() { results <- refreshRequest(s, "Bearer "+session.RefreshToken).Code }()
+	}
+	a, b := <-results, <-results
+	if !((a == 200 && b >= 400) || (b == 200 && a >= 400)) {
+		t.Fatalf("expected one success, got %d and %d", a, b)
+	}
+	var count int64
+	if err := s.db.Client().Model(&models.RefreshToken{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected one refresh token, got %d", count)
+	}
+}
+
+func TestRefreshSessionRollback(t *testing.T) {
+	s, session := setupRefreshTest(t)
+	if err := s.db.Client().Exec(`CREATE TRIGGER reject_refresh BEFORE INSERT ON refresh_tokens BEGIN SELECT RAISE(ABORT, 'test failure'); END`).Error; err != nil {
+		t.Fatal(err)
+	}
+	if w := refreshRequest(s, "Bearer "+session.RefreshToken); w.Code < 400 {
+		t.Fatal("expected insertion failure")
+	}
+	for _, table := range []string{"tokens", "refresh_tokens"} {
+		var count int64
+		if err := s.db.Client().Table(table).Count(&count).Error; err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Fatalf("%s: expected original row only, got %d", table, count)
+		}
+	}
+	if err := s.db.Client().Exec("DROP TRIGGER reject_refresh").Error; err != nil {
+		t.Fatal(err)
+	}
+	if w := refreshRequest(s, "Bearer "+session.RefreshToken); w.Code != 200 {
+		t.Fatalf("original credential not restored: %d", w.Code)
+	}
+}

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -50,6 +50,11 @@ func (s *Server) handleLegacySessionMiddleware(next echo.HandlerFunc) echo.Handl
 			return helpers.ServerError(e, nil)
 		}
 
+		isRefresh := e.Request().URL.Path == "/xrpc/com.atproto.server.refreshSession"
+		if isRefresh && !strings.EqualFold(pts[0], "Bearer") {
+			return helpers.InvalidTokenError(e)
+		}
+
 		// move on to oauth session middleware if this is a dpop token
 		if pts[0] == "DPoP" {
 			return next(e)
@@ -166,10 +171,9 @@ func (s *Server) handleLegacySessionMiddleware(next echo.HandlerFunc) echo.Handl
 			}
 		}
 
-		isRefresh := e.Request().URL.Path == "/xrpc/com.atproto.server.refreshSession"
 		scope, _ := claims["scope"].(string)
 
-		if isRefresh && scope != "com.atproto.refresh" {
+		if isRefresh && (hasLxm || scope != "com.atproto.refresh") {
 			return helpers.InvalidTokenError(e)
 		} else if !hasLxm && !isRefresh && scope != "com.atproto.access" {
 			return helpers.InvalidTokenError(e)
@@ -225,6 +229,7 @@ func (s *Server) handleLegacySessionMiddleware(next echo.HandlerFunc) echo.Handl
 		e.Set("repo", repo)
 		e.Set("did", did)
 		e.Set("token", tokenstr)
+		e.Set("legacyRefresh", isRefresh)
 
 		if err := next(e); err != nil {
 			return helpers.InvalidTokenError(e)

--- a/server/session.go
+++ b/server/session.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
+	"github.com/haileyok/cocoon/internal/db"
 	"github.com/haileyok/cocoon/models"
 )
 
@@ -15,6 +16,11 @@ type Session struct {
 }
 
 func (s *Server) createSession(ctx context.Context, repo *models.Repo) (*Session, error) {
+	return s.createSessionWithDB(ctx, s.db, repo)
+}
+
+// createSessionWithDB lets refresh rotation persist both tokens in its transaction.
+func (s *Server) createSessionWithDB(ctx context.Context, database *db.DB, repo *models.Repo) (*Session, error) {
 	now := time.Now()
 	accexp := now.Add(3 * time.Hour)
 	refexp := now.Add(7 * 24 * time.Hour)
@@ -51,7 +57,7 @@ func (s *Server) createSession(ctx context.Context, repo *models.Repo) (*Session
 		return nil, err
 	}
 
-	if err := s.db.Create(ctx, &models.Token{
+	if err := database.Create(ctx, &models.Token{
 		Token:        accessString,
 		Did:          repo.Did,
 		RefreshToken: refreshString,
@@ -61,7 +67,7 @@ func (s *Server) createSession(ctx context.Context, repo *models.Repo) (*Session
 		return nil, err
 	}
 
-	if err := s.db.Create(ctx, &models.RefreshToken{
+	if err := database.Create(ctx, &models.RefreshToken{
 		Token:     refreshString,
 		Did:       repo.Did,
 		CreatedAt: now,


### PR DESCRIPTION
This keeps `refreshSession` limited to legacy refresh tokens. OAuth/DPoP credentials can no longer use it to obtain legacy sessions.

Rotation now runs in a single transaction: it must consume exactly one valid refresh token before issuing replacements. Concurrent requests can’t create separate sessions, and failed rotations preserve the original credentials.

Added regression tests for OAuth rejection, normal refresh, replay, concurrency, and rollback.

Kept this focused on refresh sessions; service-auth and proxy authorization will follow separately.