### PR TITLE
fix(server): use html/template to escape OAuth consent pages

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"log/slog"
 	"net/http"
@@ -14,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"text/template"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/server/templates_xss_test.go
+++ b/server/templates_xss_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// The OAuth consent and account-management pages render data that originates
+// off-server (client metadata fetched from the client's own host) alongside
+// local user data. These tests execute the production TemplateRenderer so
+// they pin the escaping behavior the server actually uses, not a test-local
+// copy of the templates.
+
+// renderWithProductionRenderer loads the embedded templates exactly as
+// production's loadTemplates does (non-dev path) and renders name with data.
+func renderWithProductionRenderer(t *testing.T, name string, data map[string]any) string {
+	t.Helper()
+
+	s := newTestServer(t)
+	e := echo.New()
+	s.echo = e
+	s.loadTemplates()
+
+	c, rec := newRequestContext(http.MethodGet, "/", "", nil)
+	if err := e.Renderer.Render(&bytes.Buffer{}, name, data, c); err != nil {
+		t.Fatalf("render %s: %v", name, err)
+	}
+	// Render into a fresh recorder for assertions.
+	buf := &bytes.Buffer{}
+	if err := e.Renderer.Render(buf, name, data, c); err != nil {
+		t.Fatalf("render %s: %v", name, err)
+	}
+	_ = rec
+	return buf.String()
+}
+
+func TestAuthorizePageEscapesClientName(t *testing.T) {
+	xss := `"/><script>alert(1)</script><img src=x onerror=alert(2)>`
+	out := renderWithProductionRenderer(t, "authorize.html", map[string]any{
+		"Scopes":       []string{"atproto"},
+		"AppName":      xss,
+		"Handle":       "alice.pds.test",
+		"RequestUri":   "urn:ietf:params:oauth:request_uri:abc123",
+		"QueryParams":  "request_uri=abc123&client_id=abc",
+		"Accounts":     []any{},
+		"ActiveDid":    "",
+		"HasLoginHint": false,
+	})
+
+	if strings.Contains(out, "<script>") || strings.Contains(out, "<img") {
+		t.Fatalf("authorize page contains unescaped client_name markup:\n%s", out)
+	}
+	// The attacker's text must still be visible (escaped), not silently dropped.
+	if !strings.Contains(out, "&lt;script&gt;") {
+		t.Fatalf("client_name was not rendered in escaped form:\n%s", out)
+	}
+}
+
+func TestAuthorizePageEscapesUserHandle(t *testing.T) {
+	xss := `alice.pds.test<script>alert(1)</script>`
+	out := renderWithProductionRenderer(t, "authorize.html", map[string]any{
+		"Scopes":       []string{"atproto"},
+		"AppName":      "Innocent App",
+		"Handle":       xss,
+		"RequestUri":   "urn:ietf:params:oauth:request_uri:abc123",
+		"QueryParams":  "request_uri=abc123",
+		"Accounts":     []any{},
+		"ActiveDid":    "",
+		"HasLoginHint": false,
+	})
+
+	if strings.Contains(out, "<script>") {
+		t.Fatalf("authorize page contains unescaped handle markup:\n%s", out)
+	}
+}
+
+// The account management page renders the client_name of every authorized
+// OAuth client (persisted XSS surface), plus token and IP data.
+func TestAccountPageEscapesClientName(t *testing.T) {
+	out := renderWithProductionRenderer(t, "account.html", map[string]any{
+		"Repo": map[string]any{
+			"Actor": map[string]any{"Handle": "alice.pds.test"},
+			"Repo":  map[string]any{"Did": "did:plc:abc"},
+		},
+		"Tokens": []map[string]string{
+			{
+				"ClientName":  `<script>alert(document.domain)</script>`,
+				"Age":         "1 minute",
+				"LastUpdated": "1 minute",
+				"ExpiresIn":   "1 hour",
+				"Token":       "secret-token",
+				"Ip":          "127.0.0.1",
+			},
+		},
+		"flashes":   map[string]any{"errors": []string{}, "successes": []string{}, "tokenrequired": []string{}},
+		"Accounts":  []any{},
+		"ActiveDid": "did:plc:abc",
+	})
+
+	if strings.Contains(out, "<script>") {
+		t.Fatalf("account page contains unescaped client_name markup:\n%s", out)
+	}
+}
+
+// The signin page renders query params and flash messages into a form; a
+// reflected value must not be able to break out of the hidden input.
+func TestSigninPageEscapesQueryParamsAndFlashes(t *testing.T) {
+	out := renderWithProductionRenderer(t, "signin.html", map[string]any{
+		"flashes":     map[string]any{"errors": []string{`Bad <script>alert(1)</script>`}, "successes": []string{}, "tokenrequired": []string{}},
+		"QueryParams": `request_uri=abc"><script>alert(1)</script>`,
+		"Accounts":    []any{},
+		"ActiveDid":   "",
+	})
+
+	if strings.Contains(out, "<script>") {
+		t.Fatalf("signin page contains unescaped query params or flash markup:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes a stored/reflected XSS on the OAuth consent page (and account-management/signin pages) by switching the server's template rendering from `text/template` to `html/template`.
- `client_name` rendered on the consent page is attacker-controlled (OAuth client metadata is fetched from the client's own host), so a malicious client could previously inject arbitrary script into the PDS origin for any user who started an OAuth flow with it.

## Changes
- `server/server.go`: `TemplateRenderer` now parses and executes templates with `html/template`, giving contextual auto-escaping to every interpolation (`.AppName`, `.Handle`, `.QueryParams`, flashes, token/IP rows).
- No template markup changes required; the same `.html` files now escape automatically.
- New `server/templates_xss_test.go` renders each page through the **production renderer** (not a test-local copy) with hostile `client_name`, handle, and query-param payloads, asserting no unescaped markup reaches the output.
- Note: `{{ .QueryParams }}` inside URL contexts now URL-encodes as a side effect of contextual escaping — e.g. `?` → `%3d`-style components in the signout/signin links. These are still valid query strings for the server's own parsing.

## Validation
- Wrote tests first and confirmed all four were red against `text/template` for the expected reason (unescaped `<script>`/`<img>` markup in output), then green after the one-line import change.
- `go build ./...`, `go vet ./...`, `gofmt -l server/` — clean.
- `go test ./...` — full suite passes.

## Review notes
- The session cookie is HttpOnly, so this XSS could not steal cookies directly, but it could auto-submit the consent POST to grant the attacker's client account authorization (the authorize POST has no CSRF token — a separate follow-up).
- Branch is based on `hailey/revert-spaces` (#136) since the revert touches the same `server/server.go` region; rebase trivially if #136 lands first.
