### PR TITLE
fix(server): cap importRepo request body at 100 MB

### DIFF
--- a/server/handle_import_repo.go
+++ b/server/handle_import_repo.go
@@ -3,7 +3,9 @@ package server
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"net/http"
 	"slices"
 	"strings"
 
@@ -16,14 +18,28 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// importRepoMaxBodyBytes caps the size of an imported repo CAR. Records-only
+// CARs are typically tens of MB even for very large accounts, so 100 MB has
+// generous headroom while preventing an authenticated user from ballooning
+// the process heap with an unbounded read.
+const importRepoMaxBodyBytes = 100 << 20
+
 func (s *Server) handleRepoImportRepo(e echo.Context) error {
 	ctx := e.Request().Context()
 	logger := s.logger.With("name", "handleImportRepo")
 
 	urepo := e.Get("repo").(*models.RepoActor)
 
-	b, err := io.ReadAll(e.Request().Body)
+	body := http.MaxBytesReader(e.Response(), e.Request().Body, importRepoMaxBodyBytes)
+	b, err := io.ReadAll(body)
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return e.JSON(http.StatusRequestEntityTooLarge, map[string]string{
+				"error":   "RequestEntityTooLarge",
+				"message": "imported repo CAR exceeds the 100 MB limit",
+			})
+		}
 		logger.Error("could not read bytes in import request", "error", err)
 		return helpers.ServerError(e, nil)
 	}

--- a/server/handle_import_repo_test.go
+++ b/server/handle_import_repo_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/haileyok/cocoon/internal/helpers"
+	"github.com/haileyok/cocoon/models"
+	"github.com/labstack/echo/v4"
+)
+
+// importRepo reads the request body with io.ReadAll. Without a size cap, an
+// authenticated user can stream an arbitrarily large body and balloon the
+// process heap. The uploadBlob endpoint caps uploads at 100 MB; importRepo
+// must enforce the same cap and reject oversized bodies without buffering
+// them.
+
+// importRepoMaxBodyBytes is defined in handle_import_repo.go (100 MB).
+
+func callImportRepo(t *testing.T, s *Server, acct *testAccount, body io.Reader) (int, string) {
+	t.Helper()
+	c, rec := newRequestContext(http.MethodPost, "/xrpc/com.atproto.repo.importRepo", "", map[string]string{"content-type": "application/octet-stream"})
+	c.Request().Body = io.NopCloser(body)
+	repo, err := s.getRepoActorByDid(context.Background(), acct.Did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+	c.Set("repo", repo)
+	if err := s.handleRepoImportRepo(c); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	return rec.Code, rec.Body.String()
+}
+
+// TestImportRepoRejectsOversizedBody: a body exceeding the import cap must be
+// rejected with 413. The body is larger than the cap (cap + 1 MiB of 'A's), so
+// a handler that reads it unboundedly would buffer past the limit; the cap
+// must cut it off first.
+func TestImportRepoRejectsOversizedBody(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+
+	oversized := io.LimitReader(newInfiniteReader(), importRepoMaxBodyBytes+(1<<20))
+	code, _ := callImportRepo(t, s, acct, oversized)
+	if code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 for oversized import body, got %d", code)
+	}
+}
+
+// TestImportRepoAcceptsSmallBody: a tiny (invalid CAR but size-in-bounds) body
+// must not trip the size cap — it should fail for CAR reasons, not 413.
+func TestImportRepoAcceptsSmallBody(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+
+	code, _ := callImportRepo(t, s, acct, strings.NewReader("not a car"))
+	if code == http.StatusRequestEntityTooLarge {
+		t.Fatalf("small body unexpectedly rejected with 413, got %d", code)
+	}
+}
+
+// infiniteReader produces an endless stream of bytes without holding them in
+// memory, so an unbounded handler would never finish reading.
+type infiniteReader struct{}
+
+func newInfiniteReader() *infiniteReader { return &infiniteReader{} }
+
+func (i *infiniteReader) Read(p []byte) (int, error) {
+	for j := range p {
+		p[j] = 0x41
+	}
+	return len(p), nil
+}
+
+var (
+	_ = bytes.MinRead
+	_ = errors.Is
+	_ = helpers.InputError
+	_ = models.TwoFactorTypeNone
+	_ = echo.MIMEOctetStream
+)


### PR DESCRIPTION
## Summary
- Caps `com.atproto.repo.importRepo` request bodies at 100 MB, fixing an authenticated memory-exhaustion vector: the handler previously `io.ReadAll`'d the entire request body with no limit, so a single user could stream an arbitrarily large body and OOM the PDS for everyone (the generous 5-minute ReadTimeout made slow large uploads practical).

## Changes
- `server/handle_import_repo.go`: the request body is wrapped in `http.MaxBytesReader(e.Response(), e.Request().Body, 100<<20)` before reading. Oversized bodies return `413 RequestEntityTooLarge` (with a clear message) instead of being buffered; the reader also aborts promptly at the limit rather than consuming the stream.
- 100 MB matches the intended single consistent limit for authenticated large uploads; records-only CARs (blobs are imported separately via `uploadBlob`) are typically tens of MB even for very large accounts, so legitimate imports have generous headroom.
- New `server/handle_import_repo_test.go`: oversized body (cap + 1 MiB) → 413; small invalid-CAR body → fails for CAR reasons, not 413.

## Validation
- Test-first: the oversized-body test failed against the unbounded handler, passes after the fix.
- `go build ./...`, `go vet ./...`, `gofmt` — clean; `go test ./...` — full suite passes.

## Review notes
- Known follow-ups tracked separately (from the security review): importRepo also skips scope enforcement, overwrites records without swapCommit, emits no firehose event, and panics on a zero-root CAR header. Those are behavior changes beyond this PR's minimal scope.
- Branch is stacked: `hailey/fix-import-body-limit` → `hailey/fix-update-email` (#139) → `hailey/fix-oauth-ssrf` (#138) → `hailey/fix-consent-xss` (#137) → `hailey/revert-spaces` (#136). Merge in that order (or rebase onto main as #136–#139 land).
- Pushed over HTTPS via gh token because the session's forwarded SSH agent socket died mid-session.
