### PR TITLE
fix: enforce OAuth RPC permissions when issuing service auth

### DIFF
--- a/server/handle_server_get_service_auth.go
+++ b/server/handle_server_get_service_auth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -35,6 +36,14 @@ func (s *Server) handleServerGetServiceAuth(e echo.Context) error {
 
 	if err := e.Validate(req); err != nil {
 		return helpers.InputError(e, nil)
+	}
+
+	if !s.hasRPCScope(e, req.Aud, req.Lxm) {
+		lxm := req.Lxm
+		if lxm == "" {
+			lxm = "*"
+		}
+		return helpers.InsufficientScopeError(e, "rpc:"+lxm+"?aud="+url.QueryEscape(req.Aud))
 	}
 
 	exp := int64(req.Exp)

--- a/server/handle_server_get_service_auth_test.go
+++ b/server/handle_server_get_service_auth_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"crypto"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/labstack/echo/v4"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+)
+
+func TestGetServiceAuthPermissions(t *testing.T) {
+	const method = "app.bsky.feed.getTimeline"
+	for _, tc := range []struct {
+		name, scope, aud, lxm string
+		legacy                bool
+		want                  int
+	}{
+		{"atproto only", "atproto", testDid, "com.atproto.repo.createRecord", false, 403},
+		{"matching RPC", "atproto rpc:" + method + "?aud=did:web:appview.test", "did:web:appview.test", method, false, 200},
+		{"wrong audience", "rpc:" + method + "?aud=did:web:other.test", "did:web:appview.test", method, false, 403},
+		{"wrong method", "rpc:app.bsky.feed.getFeed?aud=did:web:appview.test", "did:web:appview.test", method, false, 403},
+		{"methodless requires wildcard", "rpc:" + method + "?aud=did:web:appview.test", "did:web:appview.test", "", false, 403},
+		{"wildcard method", "rpc:*?aud=did:web:appview.test", "did:web:appview.test", "", false, 200},
+		{"wildcard audience", "rpc:" + method + "?aud=*", "did:web:appview.test", method, false, 200},
+		{"generic", "atproto transition:generic", "did:web:appview.test", method, false, 200},
+		{"generic excludes chat", "transition:generic", "did:web:chat.test", "chat.bsky.convo.getConvo", false, 403},
+		{"chat", "transition:chat.bsky", "did:web:chat.test", "chat.bsky.convo.getConvo", false, 200},
+		{"chat excludes other RPCs", "transition:chat.bsky", "did:web:appview.test", method, false, 403},
+		{"email grants no RPC", "transition:email", "did:web:appview.test", method, false, 403},
+		{"legacy unchanged", "", "did:web:appview.test", method, true, 200},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestServer(t)
+			attachOauthProvider(t, s)
+			account := s.createTestAccount(t, "service.pds.test")
+			repo, err := s.getRepoActorByDid(context.Background(), account.Did)
+			if err != nil {
+				t.Fatal(err)
+			}
+			s.echo = echo.New()
+			s.echo.Validator = newTestValidator()
+			s.addRoutes()
+			target := "/xrpc/com.atproto.server.getServiceAuth?" + url.Values{"aud": {tc.aud}, "lxm": {tc.lxm}}.Encode()
+			r := httptest.NewRequest(http.MethodGet, target, nil)
+			if tc.legacy {
+				session, err := s.createSession(context.Background(), &repo.Repo)
+				if err != nil {
+					t.Fatal(err)
+				}
+				r.Header.Set("Authorization", "Bearer "+session.AccessToken)
+			} else {
+				// Seed an OAuth resource grant with a real, matching DPoP proof.
+				access := "service-auth-test-access"
+				proof := newTestDpopProof(t, s, http.MethodGet, "https://"+testHostname+target, &access)
+				parsed, _, err := new(jwt.Parser).ParseUnverified(proof, jwt.MapClaims{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				keyJSON, err := json.Marshal(parsed.Header["jwk"])
+				if err != nil {
+					t.Fatal(err)
+				}
+				key, err := jwk.ParseKey(keyJSON)
+				if err != nil {
+					t.Fatal(err)
+				}
+				thumb, err := key.Thumbprint(crypto.SHA256)
+				if err != nil {
+					t.Fatal(err)
+				}
+				jkt := base64.RawURLEncoding.EncodeToString(thumb)
+				grant := provider.OauthToken{
+					Token: access, Sub: account.Did, ClientId: "http://localhost",
+					RefreshToken: "service-auth-test-refresh", ExpiresAt: time.Now().Add(time.Hour),
+					Parameters: provider.ParRequest{Scope: tc.scope, DpopJkt: &jkt},
+				}
+				if err := s.db.Create(context.Background(), &grant, nil).Error; err != nil {
+					t.Fatal(err)
+				}
+				r.Header.Set("Authorization", "DPoP "+access)
+				r.Header.Set("DPoP", proof)
+			}
+			w := httptest.NewRecorder()
+			s.echo.ServeHTTP(w, r)
+			if w.Code != tc.want {
+				t.Fatalf("status = %d, want %d", w.Code, tc.want)
+			}
+			var response map[string]string
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
+			if tc.want == 403 {
+				if response["error"] != "insufficient_scope" || response["token"] != "" {
+					t.Fatal("expected insufficient_scope without a service token")
+				}
+				return
+			}
+			token, _, err := new(jwt.Parser).ParseUnverified(response["token"], jwt.MapClaims{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			claims := token.Claims.(jwt.MapClaims)
+			if claims["iss"] != account.Did || claims["aud"] != tc.aud {
+				t.Fatal("service token changed subject or audience")
+			}
+			if tc.lxm == "" {
+				if _, ok := claims["lxm"]; ok {
+					t.Fatal("methodless token unexpectedly contains lxm")
+				}
+			} else if claims["lxm"] != tc.lxm {
+				t.Fatal("service token changed method")
+			}
+		})
+	}
+}

--- a/server/scope_enforcement.go
+++ b/server/scope_enforcement.go
@@ -1,9 +1,49 @@
 package server
 
 import (
+	"strings"
+
 	"github.com/haileyok/cocoon/oauth/scopes"
 	"github.com/labstack/echo/v4"
 )
+
+// hasRPCScope checks the exact method and audience before delegating authority.
+// An omitted method requests an unrestricted token and requires lxm=*.
+func (s *Server) hasRPCScope(e echo.Context, aud, lxm string) bool {
+	raw := e.Get("scopes")
+	if raw == nil {
+		// Only authenticated legacy bearer requests may omit OAuth scope state.
+		scheme, _, _ := strings.Cut(e.Request().Header.Get("Authorization"), " ")
+		return strings.EqualFold(scheme, "Bearer")
+	}
+	granted, ok := raw.([]string)
+	if !ok {
+		return false
+	}
+	if lxm == "" {
+		lxm = "*"
+	}
+	for _, tok := range granted {
+		sc, err := scopes.Parse(tok)
+		if err != nil {
+			continue
+		}
+		if sc.Resource == scopes.ResourceTransition {
+			chat := strings.HasPrefix(lxm, "chat.bsky.")
+			if (sc.Transition == "generic" && !chat) || (sc.Transition == "chat.bsky" && chat) {
+				return true
+			}
+		}
+		if sc.Resource == scopes.ResourceRPC && (sc.Aud == aud || sc.Aud == "*") {
+			for _, method := range sc.Lxm {
+				if method == lxm || method == "*" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
 
 // actionForOpType maps a repo OpType to its scope action verb.
 func actionForOpType(t OpType) string {

--- a/server/scope_enforcement_test.go
+++ b/server/scope_enforcement_test.go
@@ -18,6 +18,33 @@ func ctxWithScopes(scopes any) echo.Context {
 	return c
 }
 
+func TestHasRPCScopeStateAndAudience(t *testing.T) {
+	var s Server
+	const method = "app.bsky.feed.getTimeline"
+	for _, tc := range []struct {
+		name, scheme, aud string
+		scopes            any
+		want              bool
+	}{
+		{"missing OAuth state", "DPoP", testDid, nil, false},
+		{"malformed OAuth state", "DPoP", testDid, "transition:generic", false},
+		{"empty OAuth state", "DPoP", testDid, []string{}, false},
+		{"legacy bearer", "bearer", testDid, nil, true},
+		{"invalid double wildcard", "DPoP", testDid, []string{"rpc:*?aud=*"}, false},
+		{"matching service fragment", "DPoP", "did:web:appview.test#view", []string{"rpc:" + method + "?aud=did:web:appview.test%23view"}, true},
+		{"different service fragment", "DPoP", "did:web:appview.test#other", []string{"rpc:" + method + "?aud=did:web:appview.test%23view"}, false},
+		{"fragment must not be discarded", "DPoP", "did:web:appview.test", []string{"rpc:" + method + "?aud=did:web:appview.test%23view"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := ctxWithScopes(tc.scopes)
+			c.Request().Header.Set("Authorization", tc.scheme+" token")
+			if got := s.hasRPCScope(c, tc.aud, method); got != tc.want {
+				t.Fatalf("hasRPCScope = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestHasRepoScope(t *testing.T) {
 	s := newTestServer(t)
 


### PR DESCRIPTION
Following up on #135, this adds the OAuth permission check to `getServiceAuth`. Before issuing a token, it checks that the grant covers the requested method and audience. Requests without a method require wildcard permission.
Legacy sessions still work as before, and the generic/chat transitional scopes keep their intended behavior.

Added regression tests for permitted and denied requests, missing or malformed scope state, and audience matching.

Keeping these small and easy to review—one more patch for proxy authorization is coming next.