### PR TITLE
feat: agentify — headless setup, OAuth consent, and management for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 
 Cocoon is a PDS implementation in Go. It is highly experimental, and is not ready for any production use.
 
+## For agents
+
+If you are an autonomous agent setting up or operating a Cocoon PDS headlessly
+(deploy → invite → createAccount → tokens → OAuth → management, no browser
+required), follow [docs/agent-setup.md](docs/agent-setup.md). Human-facing
+setup continues below.
+
 ## Quick Start with Docker Compose
 
 ### Prerequisites

--- a/cmd/cocoon/main.go
+++ b/cmd/cocoon/main.go
@@ -479,13 +479,15 @@ var runRecommitRepos = &cli.Command{
 		}
 
 		dryRun := !cmd.Bool("confirm")
+		// Banners and the migration logger go to real stderr so stdout stays
+		// pure (JSON or prose) even when the app's ErrWriter is overridden.
 		if dryRun {
-			fmt.Fprintln(cmd.App.ErrWriter, "DRY RUN — no changes will be made. Re-run with --confirm to apply.")
+			fmt.Fprintln(os.Stderr, "DRY RUN — no changes will be made. Re-run with --confirm to apply.")
 		} else {
-			fmt.Fprintln(cmd.App.ErrWriter, "APPLYING changes. Ensure the PDS is STOPPED to avoid firehose sequence collisions.")
+			fmt.Fprintln(os.Stderr, "APPLYING changes. Ensure the PDS is STOPPED to avoid firehose sequence collisions.")
 		}
 
-		logger := slog.New(slog.NewTextHandler(cmd.App.ErrWriter, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 		results, err := server.RunRecommitMigration(context.Background(), gdb, server.RecommitOptions{
 			Dids:              dids,
 			DryRun:            dryRun,

--- a/cmd/cocoon/main.go
+++ b/cmd/cocoon/main.go
@@ -29,7 +29,17 @@ import (
 var Version = "dev"
 
 func main() {
-	app := &cli.App{
+	app := newApp(Version)
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Printf("Error: %v\n", err)
+	}
+}
+
+// newApp constructs the cocoon cli.App. It is package-level so tests can drive
+// the CLI in-process with a custom Writer.
+func newApp(version string) *cli.App {
+	return &cli.App{
 		Name:  "cocoon",
 		Usage: "An atproto PDS",
 		Flags: []cli.Flag{
@@ -175,11 +185,7 @@ func main() {
 			runRecommitRepos,
 		},
 		ErrWriter: os.Stdout,
-		Version:   Version,
-	}
-
-	if err := app.Run(os.Args); err != nil {
-		fmt.Printf("Error: %v\n", err)
+		Version:   version,
 	}
 }
 
@@ -343,6 +349,10 @@ var runCreateInviteCode = &cli.Command{
 			Usage: "number of times the invite code can be used",
 			Value: 1,
 		},
+		&cli.BoolFlag{
+			Name:  "json",
+			Usage: "output machine-parseable JSON instead of prose",
+		},
 	},
 	Action: func(cmd *cli.Context) error {
 		db, err := newDb(cmd)
@@ -368,7 +378,15 @@ var runCreateInviteCode = &cli.Command{
 			return err
 		}
 
-		fmt.Printf("New invite code created with %d uses: %s\n", uses, code)
+		if cmd.Bool("json") {
+			return json.NewEncoder(cmd.App.Writer).Encode(struct {
+				Code string `json:"code"`
+				Uses int    `json:"uses"`
+				For  string `json:"for"`
+			}{Code: code, Uses: uses, For: cmd.String("for")})
+		}
+
+		fmt.Fprintf(cmd.App.Writer, "New invite code created with %d uses: %s\n", uses, code)
 
 		return nil
 	},
@@ -381,6 +399,10 @@ var runResetPassword = &cli.Command{
 		&cli.StringFlag{
 			Name:  "did",
 			Usage: "did of the user who's password you want to reset",
+		},
+		&cli.BoolFlag{
+			Name:  "json",
+			Usage: "output machine-parseable JSON instead of prose",
 		},
 	},
 	Action: func(cmd *cli.Context) error {
@@ -405,7 +427,14 @@ var runResetPassword = &cli.Command{
 			return err
 		}
 
-		fmt.Printf("Password for %s has been reset to: %s", did.String(), newPass)
+		if cmd.Bool("json") {
+			return json.NewEncoder(cmd.App.Writer).Encode(struct {
+				Did      string `json:"did"`
+				Password string `json:"password"`
+			}{Did: did.String(), Password: newPass})
+		}
+
+		fmt.Fprintf(cmd.App.Writer, "Password for %s has been reset to: %s", did.String(), newPass)
 
 		return nil
 	},
@@ -428,6 +457,10 @@ var runRecommitRepos = &cli.Command{
 			Name:  "confirm",
 			Usage: "actually apply changes (otherwise dry-run)",
 		},
+		&cli.BoolFlag{
+			Name:  "json",
+			Usage: "output machine-parseable JSON instead of prose",
+		},
 	},
 	Action: func(cmd *cli.Context) error {
 		dids := cmd.StringSlice("dids")
@@ -447,12 +480,12 @@ var runRecommitRepos = &cli.Command{
 
 		dryRun := !cmd.Bool("confirm")
 		if dryRun {
-			fmt.Println("DRY RUN — no changes will be made. Re-run with --confirm to apply.")
+			fmt.Fprintln(cmd.App.ErrWriter, "DRY RUN — no changes will be made. Re-run with --confirm to apply.")
 		} else {
-			fmt.Println("APPLYING changes. Ensure the PDS is STOPPED to avoid firehose sequence collisions.")
+			fmt.Fprintln(cmd.App.ErrWriter, "APPLYING changes. Ensure the PDS is STOPPED to avoid firehose sequence collisions.")
 		}
 
-		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		logger := slog.New(slog.NewTextHandler(cmd.App.ErrWriter, &slog.HandlerOptions{Level: slog.LevelInfo}))
 		results, err := server.RunRecommitMigration(context.Background(), gdb, server.RecommitOptions{
 			Dids:              dids,
 			DryRun:            dryRun,
@@ -463,22 +496,60 @@ var runRecommitRepos = &cli.Command{
 			return err
 		}
 
+		if cmd.Bool("json") {
+			// Serialize errors as strings so the whole array is valid JSON.
+			type jsonResult struct {
+				Did         string `json:"did"`
+				OldRev      string `json:"oldRev"`
+				NewRev      string `json:"newRev"`
+				OldHead     string `json:"oldHead"`
+				NewHead     string `json:"newHead"`
+				Recommitted bool   `json:"recommitted"`
+				Err         string `json:"err,omitempty"`
+			}
+			out := make([]jsonResult, 0, len(results))
+			var failures int
+			for _, r := range results {
+				errStr := ""
+				if r.Err != nil {
+					errStr = r.Err.Error()
+					failures++
+				}
+				out = append(out, jsonResult{
+					Did:         r.Did,
+					OldRev:      r.OldRev,
+					NewRev:      r.NewRev,
+					OldHead:     r.OldHead,
+					NewHead:     r.NewHead,
+					Recommitted: r.Recommitted,
+					Err:         errStr,
+				})
+			}
+			if err := json.NewEncoder(cmd.App.Writer).Encode(out); err != nil {
+				return err
+			}
+			if failures > 0 {
+				return fmt.Errorf("%d repo(s) failed", failures)
+			}
+			return nil
+		}
+
 		var failures int
 		for _, r := range results {
 			if r.Err != nil {
 				failures++
-				fmt.Printf("  %s: ERROR: %v\n", r.Did, r.Err)
+				fmt.Fprintf(cmd.App.Writer, "  %s: ERROR: %v\n", r.Did, r.Err)
 				continue
 			}
 			switch {
 			case dryRun && r.Recommitted:
-				fmt.Printf("  %s: would recommit (rev %q -> new TID), then emit #sync/#identity/#account\n", r.Did, r.OldRev)
+				fmt.Fprintf(cmd.App.Writer, "  %s: would recommit (rev %q -> new TID), then emit #sync/#identity/#account\n", r.Did, r.OldRev)
 			case dryRun:
-				fmt.Printf("  %s: rev %q already valid; would emit #sync/#identity/#account only\n", r.Did, r.OldRev)
+				fmt.Fprintf(cmd.App.Writer, "  %s: rev %q already valid; would emit #sync/#identity/#account only\n", r.Did, r.OldRev)
 			case r.Recommitted:
-				fmt.Printf("  %s: recommitted rev %q -> %q, head %s -> %s; emitted #sync/#identity/#account\n", r.Did, r.OldRev, r.NewRev, r.OldHead, r.NewHead)
+				fmt.Fprintf(cmd.App.Writer, "  %s: recommitted rev %q -> %q, head %s -> %s; emitted #sync/#identity/#account\n", r.Did, r.OldRev, r.NewRev, r.OldHead, r.NewHead)
 			default:
-				fmt.Printf("  %s: rev %q already valid; emitted #sync/#identity/#account\n", r.Did, r.OldRev)
+				fmt.Fprintf(cmd.App.Writer, "  %s: rev %q already valid; emitted #sync/#identity/#account\n", r.Did, r.OldRev)
 			}
 		}
 		if failures > 0 {

--- a/cmd/cocoon/main_test.go
+++ b/cmd/cocoon/main_test.go
@@ -223,6 +223,39 @@ func TestRecommitReposJson(t *testing.T) {
 	}
 }
 
+// TestRecommitReposJsonStdoutPureUnderProductionErrWriter reproduces the
+// production wiring — newApp sets ErrWriter to os.Stdout — and asserts the
+// stdout payload still parses as JSON: banners and the migration logger must
+// go to real stderr, never through App.ErrWriter.
+func TestRecommitReposJsonStdoutPureUnderProductionErrWriter(t *testing.T) {
+	dbPath := setupTestDb(t)
+
+	did := "did:plc:recommitpurityabcdefg"
+	rootC, err := cid.Decode("bafyreib77klh3jlrqhxnp5g4bgnknpriegseaxa5uq5ktjcvmjn7vwdy4e")
+	if err != nil {
+		t.Fatalf("decode cid: %v", err)
+	}
+	seedRepo(t, dbPath, did, "badrev", rootC.Bytes())
+
+	var buf bytes.Buffer
+	app := newApp("test")
+	app.Writer = &buf
+	// exactly the production mis-direction: ErrWriter == stdout target
+	app.ErrWriter = &buf
+
+	if err := app.Run([]string{"cocoon", "--db-name", dbPath, "recommit-repos", "--json", "--dids", did}); err != nil {
+		t.Fatalf("app.Run: %v", err)
+	}
+
+	var results []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &results); err != nil {
+		t.Fatalf("stdout is not pure JSON under production ErrWriter wiring: %q: %v", buf.String(), err)
+	}
+	if len(results) != 1 || results[0]["did"] != did {
+		t.Fatalf("unexpected results: %s", buf.String())
+	}
+}
+
 func seedRepo(t *testing.T, dbPath, did, rev string, root []byte) {
 	t.Helper()
 

--- a/cmd/cocoon/main_test.go
+++ b/cmd/cocoon/main_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/haileyok/cocoon/models"
+	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/ipfs/go-cid"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// setupTestDb creates a pre-migrated temp SQLite DB (the CLI never migrates;
+// AutoMigrate runs only in server.New) and returns its path.
+func setupTestDb(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "cocoon-cli-test.db")
+	gdb, err := gorm.Open(sqlite.Open(path), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := gdb.AutoMigrate(
+		&models.Actor{},
+		&models.Repo{},
+		&models.InviteCode{},
+		&models.Token{},
+		&models.RefreshToken{},
+		&models.Block{},
+		&models.Record{},
+		&models.Blob{},
+		&models.BlobPart{},
+		&models.ReservedKey{},
+		&provider.OauthToken{},
+		&provider.OauthAuthorizationRequest{},
+		&models.EventRecord{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	sqlDB, err := gdb.DB()
+	if err != nil {
+		t.Fatalf("get sql db: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	return path
+}
+
+// runCli builds the app with a captured writer and runs args (argv without
+// argv[0]... actually including the "cocoon" program name).
+func runCli(t *testing.T, args ...string) (string, *gorm.DB) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	var errBuf bytes.Buffer
+	app := newApp("test")
+	app.Writer = &buf
+	app.ErrWriter = &errBuf
+
+	if err := app.Run(append([]string{"cocoon"}, args...)); err != nil {
+		t.Fatalf("app.Run(%v): %v", args, err)
+	}
+
+	// reopen the db named on the command line for assertions
+	dbName := ""
+	for i, a := range args {
+		if a == "--db-name" && i+1 < len(args) {
+			dbName = args[i+1]
+		}
+	}
+	gdb, err := gorm.Open(sqlite.Open(dbName), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("reopen sqlite: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := gdb.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	return buf.String(), gdb
+}
+
+func TestCreateInviteCodeJson(t *testing.T) {
+	dbPath := setupTestDb(t)
+
+	out, gdb := runCli(t, "--db-name", dbPath, "create-invite-code", "--json", "--uses", "3")
+
+	var resp struct {
+		Code string `json:"code"`
+		Uses int    `json:"uses"`
+		For  string `json:"for"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("decode json output %q: %v", out, err)
+	}
+	if resp.Code == "" {
+		t.Fatalf("expected non-empty code, got %q", out)
+	}
+	if resp.Uses != 3 {
+		t.Fatalf("expected uses 3, got %d", resp.Uses)
+	}
+	if resp.For != "" {
+		t.Fatalf("expected empty for, got %q", resp.For)
+	}
+
+	var row models.InviteCode
+	if err := gdb.Where("code = ?", resp.Code).First(&row).Error; err != nil {
+		t.Fatalf("load invite code row: %v", err)
+	}
+	if row.RemainingUseCount != 3 {
+		t.Fatalf("expected remaining_use_count 3, got %d", row.RemainingUseCount)
+	}
+}
+
+func TestCreateInviteCodeLegacyOutput(t *testing.T) {
+	dbPath := setupTestDb(t)
+
+	out, _ := runCli(t, "--db-name", dbPath, "create-invite-code")
+
+	// byte-identical legacy shape: "New invite code created with N uses: CODE\n"
+	if len(out) == 0 || out[:1] != "N" {
+		t.Fatalf("expected legacy prose output, got %q", out)
+	}
+	var in struct {
+		Uses int
+		Code string
+	}
+	// proves it is NOT json
+	if err := json.Unmarshal([]byte(out), &in); err == nil && in.Code != "" {
+		t.Fatalf("expected non-json output, got %q", out)
+	}
+	if !bytes.Contains([]byte(out), []byte("New invite code created with 1 uses: ")) {
+		t.Fatalf("expected legacy sentence, got %q", out)
+	}
+}
+
+func TestResetPasswordJson(t *testing.T) {
+	dbPath := setupTestDb(t)
+
+	did := "did:plc:resetpasstestabcdefg"
+	seedRepo(t, dbPath, did, "badrev", nil)
+
+	out, gdb := runCli(t, "--db-name", dbPath, "reset-password", "--json", "--did", did)
+
+	var resp struct {
+		Did      string `json:"did"`
+		Password string `json:"password"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		t.Fatalf("decode json output %q: %v", out, err)
+	}
+	if resp.Did != did {
+		t.Fatalf("expected did %q, got %q", did, resp.Did)
+	}
+	if resp.Password == "" {
+		t.Fatalf("expected non-empty password, got %q", out)
+	}
+
+	var row models.Repo
+	if err := gdb.Where("did = ?", did).First(&row).Error; err != nil {
+		t.Fatalf("load repo row: %v", err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(row.Password), []byte(resp.Password)); err != nil {
+		t.Fatalf("stored password does not match reported password: %v", err)
+	}
+}
+
+func TestResetPasswordLegacyOutput(t *testing.T) {
+	dbPath := setupTestDb(t)
+
+	did := "did:plc:resetpasslegacyabcdef"
+	seedRepo(t, dbPath, did, "badrev", nil)
+
+	out, _ := runCli(t, "--db-name", dbPath, "reset-password", "--did", did)
+
+	if !bytes.Contains([]byte(out), []byte("Password for "+did+" has been reset to: ")) {
+		t.Fatalf("expected legacy sentence, got %q", out)
+	}
+}
+
+func TestRecommitReposJson(t *testing.T) {
+	dbPath := setupTestDb(t)
+
+	did := "did:plc:recommittestabcdefg"
+	rootC, err := cid.Decode("bafyreib77klh3jlrqhxnp5g4bgnknpriegseaxa5uq5ktjcvmjn7vwdy4e")
+	if err != nil {
+		t.Fatalf("decode cid: %v", err)
+	}
+	seedRepo(t, dbPath, did, "badrev", rootC.Bytes())
+
+	out, _ := runCli(t, "--db-name", dbPath, "recommit-repos", "--json", "--dids", did)
+
+	var results []map[string]any
+	if err := json.Unmarshal([]byte(out), &results); err != nil {
+		t.Fatalf("decode json output %q: %v", out, err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d (%s)", len(results), out)
+	}
+	r := results[0]
+	if r["did"] != did {
+		t.Fatalf("expected did %q, got %v", did, r["did"])
+	}
+	if r["recommitted"] != true {
+		t.Fatalf("expected recommitted true for invalid rev, got %v (result %v)", r["recommitted"], r)
+	}
+	if r["oldRev"] != "badrev" {
+		t.Fatalf("expected oldRev badrev, got %v", r["oldRev"])
+	}
+	if r["err"] != "" && r["err"] != nil {
+		t.Fatalf("expected no error in result, got %v", r["err"])
+	}
+}
+
+func seedRepo(t *testing.T, dbPath, did, rev string, root []byte) {
+	t.Helper()
+
+	gdb, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
+		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() {
+		if sqlDB, err := gdb.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	}()
+
+	repo := models.Repo{
+		Did:        did,
+		CreatedAt:  time.Now(),
+		Rev:        rev,
+		Root:       root,
+		SigningKey: []byte("not-a-real-key"),
+	}
+	if err := gdb.Create(&repo).Error; err != nil {
+		t.Fatalf("seed repo: %v", err)
+	}
+	actor := models.Actor{Did: did, Handle: did + ".test"}
+	if err := gdb.Create(&actor).Error; err != nil {
+		t.Fatalf("seed actor: %v", err)
+	}
+}

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -246,8 +246,9 @@ curl -fsS -u "admin:$ADMIN_PASSWORD" "https://$HOST/admin/account?did=<did>"
 # {"did":"...","handle":"...","email":"...","emailConfirmed":false,"active":true,"status":"","twoFactorType":"none","createdAt":"...","rev":"..."}
 ```
 
-`active` is derived (true unless the account is taken down/suspended/deactivated);
-`status` is the specific state (`takendown`/`suspended`/`deactivated`) or empty.
+`active` is derived (true unless the account is deactivated);
+`status` is `"deactivated"` or empty (other states like takendown/suspended
+are not currently produced by this implementation).
 
 **Mint invite codes** — see step 2. `createInviteCodes` (plural) takes
 `{"useCount": N}` and mints multiple codes.

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -8,12 +8,59 @@ output.
 
 Conventions used below:
 
-- `$HOST` — your PDS hostname (e.g. `pds.example.com`)
-- `$ADMIN_PASSWORD` — the value of `COCOON_ADMIN_PASSWORD` in `.env`
+- `$BASE` — the base URL of your PDS: `http://localhost:8080` for the binary
+  option, `https://$HOST` for Docker (where `$HOST` is your domain)
+- `$ADMIN_PASSWORD` — the value of `COCOON_ADMIN_PASSWORD`
 - Admin HTTP auth is HTTP Basic with username `admin` and that password
 - JSON parsing is with `jq`; commands are `bash`
 
 ## 1. Deploy
+
+You need a running Cocoon server reachable over HTTP. Two ways to get one —
+pick whichever fits your environment. The **binary** path is usually simpler
+for an agent that already controls a machine: no domain, no TLS, no Docker.
+
+### Option A: run the binary directly (no Docker, no domain required)
+
+Cocoon serves plain HTTP on `:8080`. For a single-operator private PDS this is
+enough: createAccount, createSession, OAuth, and all management endpoints work
+over HTTP. (A domain + TLS matters when other network participants — relays,
+other Bluesky clients — need to reach your PDS; the OAuth metadata advertises
+`https://` issuer URLs, so use Option B or a reverse proxy when you need
+federation.)
+
+```bash
+# 1. build — the -ldflags version stamp matters: without it the binary runs
+#    in "dev" mode and expects ./server/templates on disk at startup
+git clone https://github.com/haileyok/cocoon.git
+cd cocoon
+go build -ldflags "-X main.Version=agent" -o cocoon ./cmd/cocoon
+
+# 2. generate the two key files the server requires
+./cocoon create-rotation-key --out rotation.key
+./cocoon create-private-jwk --out jwk.key
+
+# 3. set the six required env vars and run
+export COCOON_DID="did:web:localhost"
+export COCOON_HOSTNAME="localhost"
+export COCOON_ROTATION_KEY_PATH="./rotation.key"
+export COCOON_JWK_PATH="./jwk.key"
+export COCOON_CONTACT_EMAIL="agent@example.com"
+export COCOON_ADMIN_PASSWORD="$(openssl rand -hex 16)"
+export COCOON_SESSION_SECRET="$(openssl rand -hex 32)"
+export COCOON_RELAYS=""   # optional; skip firehose crawl announcements
+
+./cocoon run &
+```
+
+All later steps then use `http://localhost:8080` as the base URL. The database
+is a single SQLite file (`cocoon.db` in the working directory) — easy to
+inspect, back up, or throw away.
+
+Prerequisite for `createAccount` without an explicit `did`: outbound network
+access to `https://plc.directory` (see section 3).
+
+### Option B: Docker Compose (domain + automatic HTTPS)
 
 Prerequisites: Docker and Docker Compose, a domain pointed at the server,
 ports 80/443 open.
@@ -24,7 +71,7 @@ cd cocoon
 cp .env.example .env
 ```
 
-Set these six required variables in `.env`:
+Set these variables in `.env`:
 
 ```bash
 COCOON_DID="did:web:$HOST"                 # or your did:plc
@@ -41,38 +88,47 @@ Start and wait for health:
 
 ```bash
 docker compose up -d
-# Poll until this returns 200:
+# Poll until this returns 200 (BASE is https://your-domain):
 curl -fsS "https://$HOST/xrpc/_health"
 ```
 
 The container generates `./rotation.key` and `./jwk.key` under `./keys/` on
 first boot if absent; data lives in `./data/`.
 
+Health check for either option:
+
+```bash
+curl -fsS "$BASE/xrpc/_health"   # $BASE is http://localhost:8080 or https://$HOST
+```
+
 ## 2. Invite code
 
 By default Cocoon requires an invite code to create an account. Three ways to
 get one:
 
-a. **Read the initial invite** the container creates on first boot:
+a. **Read the initial invite** the compose stack creates on first boot
+   (Docker option only — the binary path has no equivalent, use b or c):
 
 ```bash
 docker compose exec cocoon cat /keys/initial-invite-code.txt
 ```
 
-b. **Mint one over HTTP** (admin Basic auth):
+b. **Mint one over HTTP** (admin Basic auth) — works for either deployment:
 
 ```bash
 curl -fsS -u "admin:$ADMIN_PASSWORD" \
   -H 'Content-Type: application/json' \
   -d '{"useCount": 1}' \
-  "https://$HOST/xrpc/com.atproto.server.createInviteCode"
+  "${BASE}/xrpc/com.atproto.server.createInviteCode"
 # {"code":"<uuid>"}
 ```
 
-c. **Via the CLI** (machine-parseable with --json):
+c. **Via the CLI** (machine-parseable with --json), pointing at the same
+   database your server is running on:
 
 ```bash
-docker compose exec cocoon /cocoon create-invite-code --json --uses 1
+docker compose exec cocoon /cocoon create-invite-code --json --uses 1   # Docker
+./cocoon create-invite-code --json --uses 1                            # binary
 # {"code":"<code>","uses":1,"for":""}
 ```
 
@@ -83,11 +139,11 @@ otherwise anyone can create accounts.
 ## 3. Provision an account
 
 ```bash
-curl -fsS -X POST "https://$HOST/xrpc/com.atproto.server.createAccount" \
+curl -fsS -X POST "${BASE}/xrpc/com.atproto.server.createAccount" \
   -H 'Content-Type: application/json' \
   -d '{
     "email": "agent@example.com",
-    "handle": "agent.example.com",
+    "handle": "<your-handle>",   # e.g. agent.localhost (binary) or agent.your-domain (Docker)
     "password": "<choose-a-password>",
     "inviteCode": "<from-step-2>"
   }'
@@ -102,7 +158,8 @@ Notes:
   egress to `https://plc.directory`. To skip the network entirely, pass an
   existing `did` you control (advanced; see the atproto DID docs).
 - **Handles**: handles live under the PDS hostname by default (e.g.
-  `agent.pds.example.com`); subdomain handle resolution is served by the PDS's
+  `agent.localhost` for the binary option, `agent.pds.example.com` for
+  Docker); subdomain handle resolution is served by the PDS's
   `/.well-known/atproto-did` route.
 - **SMTP is optional**: all mail functions no-op when unset, and email
   confirmation is never a gate — the account is usable immediately.
@@ -115,9 +172,9 @@ For all XRPC calls you can use the legacy session tokens — this is the
 simplest authenticated path:
 
 ```bash
-curl -fsS -X POST "https://$HOST/xrpc/com.atproto.server.createSession" \
+curl -fsS -X POST "${BASE}/xrpc/com.atproto.server.createSession" \
   -H 'Content-Type: application/json' \
-  -d '{"identifier": "agent.example.com", "password": "<password>"}'
+  -d '{"identifier": "<your-handle>", "password": "<password>"}'
 # {"accessJwt": "...", "refreshJwt": "...", ...}
 ```
 
@@ -135,7 +192,7 @@ Prove the write loop works with a concrete record:
 
 ```bash
 RKEY="self-test-$(date +%s)"
-curl -fsS -X POST "https://$HOST/xrpc/com.atproto.repo.createRecord" \
+curl -fsS -X POST "${BASE}/xrpc/com.atproto.repo.createRecord" \
   -H "Authorization: Bearer $ACCESS_JWT" \
   -H 'Content-Type: application/json' \
   -d '{
@@ -150,7 +207,7 @@ curl -fsS -X POST "https://$HOST/xrpc/com.atproto.repo.createRecord" \
 Verify it reads back:
 
 ```bash
-curl -fsS "https://$HOST/xrpc/com.atproto.repo.getRecord?repo=<did>&collection=com.atproto.identity.verifiableStatement&rkey=$RKEY"
+curl -fsS "${BASE}/xrpc/com.atproto.repo.getRecord?repo=<did>&collection=com.atproto.identity.verifiableStatement&rkey=$RKEY"
 ```
 
 ## 6. Full OAuth client flow (DPoP-bound, spec-compliant)
@@ -167,8 +224,8 @@ Steps:
 1. **Fetch metadata**:
 
 ```bash
-curl -fsS "https://$HOST/.well-known/oauth-protected-resource"
-curl -fsS "https://$HOST/.well-known/oauth-authorization-server"
+curl -fsS "${BASE}/.well-known/oauth-protected-resource"
+curl -fsS "${BASE}/.well-known/oauth-authorization-server"
 ```
 
 2. **Register a client**: host a client metadata document at an `https://`
@@ -180,7 +237,7 @@ curl -fsS "https://$HOST/.well-known/oauth-authorization-server"
    authorization request and returns a `request_uri`:
 
 ```bash
-curl -fsS -X POST "https://$HOST/oauth/par" \
+curl -fsS -X POST "${BASE}/oauth/par" \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -H "DPoP: <your-dpop-proof-jwt>" \
   --data-urlencode "client_id=http://localhost" \
@@ -200,7 +257,7 @@ curl -fsS -X POST "https://$HOST/oauth/par" \
 4. **Admin-minted consent** — replaces the human "Accept" click:
 
 ```bash
-curl -fsS -X POST "https://$HOST/admin/oauth/authorize" \
+curl -fsS -X POST "${BASE}/admin/oauth/authorize" \
   -u "admin:$ADMIN_PASSWORD" \
   -H 'Content-Type: application/json' \
   -d '{"requestUri": "<request_uri from step 3>", "did": "<did from step 3 of setup>"}'
@@ -214,7 +271,7 @@ curl -fsS -X POST "https://$HOST/admin/oauth/authorize" \
 5. **Token exchange** (standard OAuth):
 
 ```bash
-curl -fsS -X POST "https://$HOST/oauth/token" \
+curl -fsS -X POST "${BASE}/oauth/token" \
   -H 'Content-Type: application/x-www-form-urlencoded' \
   -H "DPoP: <your-dpop-proof-jwt>" \
   --data-urlencode "grant_type=authorization_code" \
@@ -235,14 +292,14 @@ All admin HTTP endpoints use Basic auth (`admin:$ADMIN_PASSWORD`).
 **List accounts** (paginated; `limit` default 100, max 500; `offset` for paging):
 
 ```bash
-curl -fsS -u "admin:$ADMIN_PASSWORD" "https://$HOST/admin/accounts?limit=100&offset=0"
+curl -fsS -u "admin:$ADMIN_PASSWORD" "${BASE}/admin/accounts?limit=100&offset=0"
 # [{"did":"...","handle":"...","email":"...","active":true,"status":"","createdAt":"..."}]
 ```
 
 **Account detail**:
 
 ```bash
-curl -fsS -u "admin:$ADMIN_PASSWORD" "https://$HOST/admin/account?did=<did>"
+curl -fsS -u "admin:$ADMIN_PASSWORD" "${BASE}/admin/account?did=<did>"
 # {"did":"...","handle":"...","email":"...","emailConfirmed":false,"active":true,"status":"","twoFactorType":"none","createdAt":"...","rev":"..."}
 ```
 
@@ -256,7 +313,8 @@ are not currently produced by this implementation).
 **Reset a password** (CLI, machine-parseable):
 
 ```bash
-docker compose exec cocoon /cocoon reset-password --json --did <did>
+docker compose exec cocoon /cocoon reset-password --json --did <did>   # Docker
+./cocoon reset-password --json --did <did>                            # binary
 # {"did":"...","password":"..."}
 ```
 
@@ -274,6 +332,10 @@ docker compose run --rm cocoon /cocoon recommit-repos --json --dids <did>[,<did2
 docker compose start cocoon
 ```
 
+For the binary option: stop the server process (Ctrl-C or `kill <pid>`), run
+`./cocoon recommit-repos --json --dids <did>[,...]`, then restart
+`./cocoon run`.
+
 ## 8. Troubleshooting
 
 **Startup exits immediately** — these validation errors are fatal and specific
@@ -286,12 +348,15 @@ docker compose start cocoon
 - `SESSION SECRET WAS NOT SET. THIS IS REQUIRED.` → `COCOON_SESSION_SECRET` missing (panics)
 - `database-url must be set when using postgres` → using `db-type=postgres` without `COCOON_DATABASE_URL`
 
-**Health**: `curl -fsS "https://$HOST/xrpc/_health"` must return 200.
+**Health**: `curl -fsS "${BASE}/xrpc/_health"` must return 200.
 
-**Where things live**:
+**Where things live** (Docker option):
 
 - `./data/` — SQLite database (or Postgres if configured)
 - `./keys/` — `rotation.key`, `jwk.key`, `initial-invite-code.txt`
+
+For the binary option: everything is in the working directory where you ran
+`./cocoon run` — `cocoon.db` (SQLite), `rotation.key`, `jwk.key`.
 
 **Account creation hangs** → check network egress to `https://plc.directory`
 (the `did:plc` minting path).

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -1,0 +1,303 @@
+# Cocoon for Agents: headless setup, OAuth, and management
+
+This runbook lets an autonomous agent stand up a Cocoon PDS, provision its own
+account, obtain session or OAuth tokens, and manage the service end-to-end —
+using only documented, machine-parseable interfaces. No browser is required at
+any step. Every step is a verifiable command; every artifact is a parseable
+output.
+
+Conventions used below:
+
+- `$HOST` — your PDS hostname (e.g. `pds.example.com`)
+- `$ADMIN_PASSWORD` — the value of `COCOON_ADMIN_PASSWORD` in `.env`
+- Admin HTTP auth is HTTP Basic with username `admin` and that password
+- JSON parsing is with `jq`; commands are `bash`
+
+## 1. Deploy
+
+Prerequisites: Docker and Docker Compose, a domain pointed at the server,
+ports 80/443 open.
+
+```bash
+git clone https://github.com/haileyok/cocoon.git
+cd cocoon
+cp .env.example .env
+```
+
+Set these six required variables in `.env`:
+
+```bash
+COCOON_DID="did:web:$HOST"                 # or your did:plc
+COCOON_HOSTNAME="$HOST"
+COCOON_ROTATION_KEY_PATH="./rotation.key"  # generated automatically if absent
+COCOON_JWK_PATH="./jwk.key"                # generated automatically if absent
+COCOON_CONTACT_EMAIL="you@example.com"
+COCOON_RELAYS="https://bsky.network"       # optional but recommended
+COCOON_ADMIN_PASSWORD="$(openssl rand -hex 16)"
+COCOON_SESSION_SECRET="$(openssl rand -hex 32)"
+```
+
+Start and wait for health:
+
+```bash
+docker compose up -d
+# Poll until this returns 200:
+curl -fsS "https://$HOST/xrpc/_health"
+```
+
+The container generates `./rotation.key` and `./jwk.key` under `./keys/` on
+first boot if absent; data lives in `./data/`.
+
+## 2. Invite code
+
+By default Cocoon requires an invite code to create an account. Three ways to
+get one:
+
+a. **Read the initial invite** the container creates on first boot:
+
+```bash
+docker compose exec cocoon cat /keys/initial-invite-code.txt
+```
+
+b. **Mint one over HTTP** (admin Basic auth):
+
+```bash
+curl -fsS -u "admin:$ADMIN_PASSWORD" \
+  -H 'Content-Type: application/json' \
+  -d '{"useCount": 1}' \
+  "https://$HOST/xrpc/com.atproto.server.createInviteCode"
+# {"code":"<uuid>"}
+```
+
+c. **Via the CLI** (machine-parseable with --json):
+
+```bash
+docker compose exec cocoon /cocoon create-invite-code --json --uses 1
+# {"code":"<code>","uses":1,"for":""}
+```
+
+`COCOON_REQUIRE_INVITE=false` disables invite requirements entirely — only do
+this for a single-operator private PDS that is not publicly reachable, since
+otherwise anyone can create accounts.
+
+## 3. Provision an account
+
+```bash
+curl -fsS -X POST "https://$HOST/xrpc/com.atproto.server.createAccount" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "email": "agent@example.com",
+    "handle": "agent.example.com",
+    "password": "<choose-a-password>",
+    "inviteCode": "<from-step-2>"
+  }'
+```
+
+Response: `{"accessJwt": "...", "refreshJwt": "...", "handle": "...", "did": "did:plc:..."}`.
+
+Notes:
+
+- **`did` field**: omit it and the server mints a fresh `did:plc` by calling
+  plc.directory **over the network** — a hang here is almost always DNS or
+  egress to `https://plc.directory`. To skip the network entirely, pass an
+  existing `did` you control (advanced; see the atproto DID docs).
+- **Handles**: handles live under the PDS hostname by default (e.g.
+  `agent.pds.example.com`); subdomain handle resolution is served by the PDS's
+  `/.well-known/atproto-did` route.
+- **SMTP is optional**: all mail functions no-op when unset, and email
+  confirmation is never a gate — the account is usable immediately.
+- The invite code is consumed atomically: a failed createAccount does not burn
+  it (unless the failure is after consumption, which is a single transaction).
+
+## 4. Session tokens
+
+For all XRPC calls you can use the legacy session tokens — this is the
+simplest authenticated path:
+
+```bash
+curl -fsS -X POST "https://$HOST/xrpc/com.atproto.server.createSession" \
+  -H 'Content-Type: application/json' \
+  -d '{"identifier": "agent.example.com", "password": "<password>"}'
+# {"accessJwt": "...", "refreshJwt": "...", ...}
+```
+
+Use `Authorization: Bearer <accessJwt>` on subsequent XRPC calls; refresh via
+`POST /xrpc/com.atproto.server.refreshSession` with the refresh token in the
+`Authorization` header.
+
+2FA is off by default. If enabled, `createSession` requires an emailed
+`authFactorToken` — keep 2FA off for agent-operated accounts, since reading
+email is not headless.
+
+## 5. First write
+
+Prove the write loop works with a concrete record:
+
+```bash
+RKEY="self-test-$(date +%s)"
+curl -fsS -X POST "https://$HOST/xrpc/com.atproto.repo.createRecord" \
+  -H "Authorization: Bearer $ACCESS_JWT" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "repo": "<did from step 3>",
+    "collection": "com.atproto.identity.verifiableStatement",
+    "rkey": "'"$RKEY"'",
+    "record": {"$type": "com.atproto.identity.verifiableStatement", "name": "agent setup self-test", "createdAt": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}
+  }'
+# {"uri": "at://<did>/com.atproto.identity.verifiableStatement/$RKEY", "cid": "..."}
+```
+
+Verify it reads back:
+
+```bash
+curl -fsS "https://$HOST/xrpc/com.atproto.repo.getRecord?repo=<did>&collection=com.atproto.identity.verifiableStatement&rkey=$RKEY"
+```
+
+## 6. Full OAuth client flow (DPoP-bound, spec-compliant)
+
+Use this when you want OAuth tokens per the atproto OAuth spec (recommended
+for any client that talks to multiple PDSes). This flow is fully headless:
+**the consent step is completed by admin authority** instead of a human
+clicking "Accept" in a browser. That means the PDS operator authorizes the
+grant — intended for self-hosted PDSes where the operator owns the accounts.
+Do not use the admin endpoint on a PDS where account owners are untrusted.
+
+Steps:
+
+1. **Fetch metadata**:
+
+```bash
+curl -fsS "https://$HOST/.well-known/oauth-protected-resource"
+curl -fsS "https://$HOST/.well-known/oauth-authorization-server"
+```
+
+2. **Register a client**: host a client metadata document at an `https://`
+   URL and use that URL as your `client_id`, **or** use the built-in
+   `http://localhost` virtual dev client (no registration needed, loopback
+   redirect URIs only, auth method `none`).
+
+3. **PAR request** (pushed authorization request) — this creates a pending
+   authorization request and returns a `request_uri`:
+
+```bash
+curl -fsS -X POST "https://$HOST/oauth/par" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -H "DPoP: <your-dpop-proof-jwt>" \
+  --data-urlencode "client_id=http://localhost" \
+  --data-urlencode "response_type=code" \
+  --data-urlencode "code_challenge=<S256-of-code-verifier>" \
+  --data-urlencode "code_challenge_method=S256" \
+  --data-urlencode "state=<random-state>" \
+  --data-urlencode "redirect_uri=http://127.0.0.1/" \
+  --data-urlencode "scope=atproto transition:generic" \
+  --data-urlencode "dpop_jkt=<jkt-of-your-dpop-key>"
+# {"expires_in": N, "request_uri": "urn:ietf:params:oauth:request_uri:..."}
+```
+
+   **PAR requests expire** (`expires_in`, on the order of minutes) — the
+   admin consent step must be completed promptly after this.
+
+4. **Admin-minted consent** — replaces the human "Accept" click:
+
+```bash
+curl -fsS -X POST "https://$HOST/admin/oauth/authorize" \
+  -u "admin:$ADMIN_PASSWORD" \
+  -H 'Content-Type: application/json' \
+  -d '{"requestUri": "<request_uri from step 3>", "did": "<did from step 3 of setup>"}'
+# {"code": "...", "state": "...", "redirectUri": "...", "iss": "https://$HOST"}
+```
+
+   This mints exactly the authorization code a signed-in human would receive;
+   DPoP `jkt` and PKCE binding are still enforced at the token endpoint, so
+   only the client that made the PAR request can exchange the code.
+
+5. **Token exchange** (standard OAuth):
+
+```bash
+curl -fsS -X POST "https://$HOST/oauth/token" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -H "DPoP: <your-dpop-proof-jwt>" \
+  --data-urlencode "grant_type=authorization_code" \
+  --data-urlencode "client_id=http://localhost" \
+  --data-urlencode "code=<code from step 4>" \
+  --data-urlencode "redirect_uri=http://127.0.0.1/" \
+  --data-urlencode "code_verifier=<the-verifier>"
+# {"access_token": "...", "refresh_token": "...", "token_type": "DPoP", "scope": "...", "sub": "<did>"}
+```
+
+Use `Authorization: DPoP <access_token>` plus a fresh DPoP proof header on
+resource requests; refresh with `grant_type=refresh_token`.
+
+## 7. Manage
+
+All admin HTTP endpoints use Basic auth (`admin:$ADMIN_PASSWORD`).
+
+**List accounts** (paginated; `limit` default 100, max 500; `offset` for paging):
+
+```bash
+curl -fsS -u "admin:$ADMIN_PASSWORD" "https://$HOST/admin/accounts?limit=100&offset=0"
+# [{"did":"...","handle":"...","email":"...","active":true,"status":"","createdAt":"..."}]
+```
+
+**Account detail**:
+
+```bash
+curl -fsS -u "admin:$ADMIN_PASSWORD" "https://$HOST/admin/account?did=<did>"
+# {"did":"...","handle":"...","email":"...","emailConfirmed":false,"active":true,"status":"","twoFactorType":"none","createdAt":"...","rev":"..."}
+```
+
+`active` is derived (true unless the account is taken down/suspended/deactivated);
+`status` is the specific state (`takendown`/`suspended`/`deactivated`) or empty.
+
+**Mint invite codes** — see step 2. `createInviteCodes` (plural) takes
+`{"useCount": N}` and mints multiple codes.
+
+**Reset a password** (CLI, machine-parseable):
+
+```bash
+docker compose exec cocoon /cocoon reset-password --json --did <did>
+# {"did":"...","password":"..."}
+```
+
+**Recommit repos** — re-mints valid TID revs for repos with invalid revs and
+re-announces their state on the firehose. **WARNING (verbatim from the CLI
+usage): because firehose events use an in-memory sequence counter, the PDS
+MUST be stopped while this runs, or sequence numbers will collide with the
+live server.**
+
+```bash
+docker compose stop cocoon
+docker compose run --rm cocoon /cocoon recommit-repos --json --dids <did>[,<did2>...]
+# [{"did":"...","oldRev":"...","newRev":"...","oldHead":"...","newHead":"...","recommitted":true}]
+# add --confirm to apply (default is dry-run); banners go to stderr, stdout is pure JSON
+docker compose start cocoon
+```
+
+## 8. Troubleshooting
+
+**Startup exits immediately** — these validation errors are fatal and specific
+(see `server/server.go`):
+
+- `cocoon did must be set` → `COCOON_DID` missing
+- `cocoon hostname must be set` → `COCOON_HOSTNAME` missing
+- `contact email must be set` → `COCOON_CONTACT_EMAIL` missing
+- `admin password must be set` → `COCOON_ADMIN_PASSWORD` missing
+- `SESSION SECRET WAS NOT SET. THIS IS REQUIRED.` → `COCOON_SESSION_SECRET` missing (panics)
+- `database-url must be set when using postgres` → using `db-type=postgres` without `COCOON_DATABASE_URL`
+
+**Health**: `curl -fsS "https://$HOST/xrpc/_health"` must return 200.
+
+**Where things live**:
+
+- `./data/` — SQLite database (or Postgres if configured)
+- `./keys/` — `rotation.key`, `jwk.key`, `initial-invite-code.txt`
+
+**Account creation hangs** → check network egress to `https://plc.directory`
+(the `did:plc` minting path).
+
+**OAuth admin consent returns "the request has expired"** → PAR requests
+expire quickly; redo step 3 (PAR) and immediately step 4 (admin consent).
+
+**401/400 on admin endpoints** → Basic auth is `admin` + the exact
+`COCOON_ADMIN_PASSWORD` value; note the server returns HTTP 400 (not 401) for
+bad credentials on admin routes.

--- a/server/docs_contract_test.go
+++ b/server/docs_contract_test.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Curated documented routes: every route docs/agent-setup.md instructs an
+// agent to call must be mentioned in the doc AND registered on the server's
+// router. Both directions are asserted so the test fails on route renames and
+// on doc omissions alike.
+var documentedAgentRoutes = []string{
+	"/xrpc/_health",
+	"/xrpc/com.atproto.server.createInviteCode",
+	"/xrpc/com.atproto.server.createAccount",
+	"/xrpc/com.atproto.server.createSession",
+	"/xrpc/com.atproto.server.refreshSession",
+	"/xrpc/com.atproto.repo.createRecord",
+	"/xrpc/com.atproto.repo.getRecord",
+	"/.well-known/atproto-did",
+	"/.well-known/oauth-protected-resource",
+	"/.well-known/oauth-authorization-server",
+	"/oauth/par",
+	"/oauth/token",
+	"/admin/oauth/authorize",
+	"/admin/accounts",
+	"/admin/account",
+}
+
+// The runbook's eight sections, asserted present so each clause of the docs
+// acceptance criteria has a failing mode.
+var documentedAgentSections = []string{
+	"## 1. Deploy",
+	"## 2. Invite code",
+	"## 3. Provision an account",
+	"## 4. Session tokens",
+	"## 5. First write",
+	"## 6. Full OAuth client flow",
+	"## 7. Manage",
+	"## 8. Troubleshooting",
+}
+
+func readDocFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// newDocsTestServer builds a server whose full route table is registered, the
+// same way Serve() does, but without starting the HTTP listener.
+func newDocsTestServer(t *testing.T) *Server {
+	t.Helper()
+
+	s := newTestServer(t)
+	attachOauthProvider(t, s)
+
+	s.echo = echo.New()
+	s.echo.Validator = newTestValidator()
+	s.addRoutes()
+	return s
+}
+
+// TestAgentSetupDocRoutesRegistered asserts every route the agent runbook
+// documents is registered on the router, and vice versa within the curated
+// list (the doc mentions each path).
+func TestAgentSetupDocRoutesRegistered(t *testing.T) {
+	doc := readDocFile(t, "../docs/agent-setup.md")
+
+	s := newDocsTestServer(t)
+	registered := map[string]bool{}
+	for _, r := range s.echo.Routes() {
+		registered[r.Path] = true
+	}
+
+	for _, path := range documentedAgentRoutes {
+		if !strings.Contains(doc, path) {
+			t.Errorf("docs/agent-setup.md does not mention documented route %s", path)
+		}
+		if !registered[path] {
+			t.Errorf("route %s is documented but not registered on the server", path)
+		}
+	}
+}
+
+// TestAgentSetupDocSections asserts all eight runbook sections are present.
+func TestAgentSetupDocSections(t *testing.T) {
+	doc := readDocFile(t, "../docs/agent-setup.md")
+	for _, section := range documentedAgentSections {
+		if !strings.Contains(doc, section) {
+			t.Errorf("docs/agent-setup.md is missing section %q", section)
+		}
+	}
+}
+
+// TestReadmeLinksAgentSetup asserts the README points agents at the runbook.
+func TestReadmeLinksAgentSetup(t *testing.T) {
+	readme := readDocFile(t, "../README.md")
+	if !strings.Contains(readme, "docs/agent-setup.md") {
+		t.Fatal("README.md does not link to docs/agent-setup.md")
+	}
+}

--- a/server/handle_admin_accounts.go
+++ b/server/handle_admin_accounts.go
@@ -75,7 +75,7 @@ func (s *Server) handleAdminAccounts(e echo.Context) error {
 	}
 
 	var repos []models.RepoActor
-	if err := s.db.Raw(ctx, "SELECT r.*, a.* FROM repos r LEFT JOIN actors a ON r.did = a.did ORDER BY r.created_at DESC LIMIT ? OFFSET ?", nil, limit, offset).Scan(&repos).Error; err != nil {
+	if err := s.db.Raw(ctx, "SELECT r.*, a.* FROM repos r LEFT JOIN actors a ON r.did = a.did ORDER BY r.created_at DESC, r.did LIMIT ? OFFSET ?", nil, limit, offset).Scan(&repos).Error; err != nil {
 		logger.Error("error listing accounts", "error", err)
 		return helpers.ServerError(e, nil)
 	}

--- a/server/handle_admin_accounts.go
+++ b/server/handle_admin_accounts.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/haileyok/cocoon/internal/helpers"
+	"github.com/haileyok/cocoon/models"
+	"github.com/labstack/echo/v4"
+)
+
+// Admin account visibility endpoints.
+//
+// Plain /admin/* routes gated by the same Basic-auth middleware as the admin
+// invite-code XRPCs: management operations, not protocol ones, so they don't
+// squat made-up NSIDs in com.atproto.*.
+
+const (
+	adminAccountsDefaultLimit = 100
+	adminAccountsMaxLimit     = 500
+)
+
+type AdminAccountsListQuery struct {
+	Limit  string `query:"limit"`
+	Offset string `query:"offset"`
+}
+
+type AdminAccountSummary struct {
+	Did       string `json:"did"`
+	Handle    string `json:"handle"`
+	Email     string `json:"email"`
+	Active    bool   `json:"active"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"createdAt"`
+}
+
+type AdminAccountDetail struct {
+	Did            string `json:"did"`
+	Handle         string `json:"handle"`
+	Email          string `json:"email"`
+	EmailConfirmed bool   `json:"emailConfirmed"`
+	Active         bool   `json:"active"`
+	Status         string `json:"status"`
+	TwoFactorType  string `json:"twoFactorType"`
+	CreatedAt      string `json:"createdAt"`
+	Rev            string `json:"rev"`
+}
+
+// handleAdminAccounts lists accounts (repos joined to actors), most recent
+// first, with derived active/status fields.
+func (s *Server) handleAdminAccounts(e echo.Context) error {
+	ctx := e.Request().Context()
+	logger := s.logger.With("name", "handleAdminAccounts")
+
+	limit := adminAccountsDefaultLimit
+	if q := e.QueryParam("limit"); q != "" {
+		n, err := strconv.Atoi(q)
+		if err != nil || n < 1 {
+			return helpers.InputError(e, to.StringPtr("limit must be a positive integer"))
+		}
+		if n > adminAccountsMaxLimit {
+			n = adminAccountsMaxLimit
+		}
+		limit = n
+	}
+
+	offset := 0
+	if q := e.QueryParam("offset"); q != "" {
+		n, err := strconv.Atoi(q)
+		if err != nil || n < 0 {
+			return helpers.InputError(e, to.StringPtr("offset must be a non-negative integer"))
+		}
+		offset = n
+	}
+
+	var repos []models.RepoActor
+	if err := s.db.Raw(ctx, "SELECT r.*, a.* FROM repos r LEFT JOIN actors a ON r.did = a.did ORDER BY r.created_at DESC LIMIT ? OFFSET ?", nil, limit, offset).Scan(&repos).Error; err != nil {
+		logger.Error("error listing accounts", "error", err)
+		return helpers.ServerError(e, nil)
+	}
+
+	out := make([]AdminAccountSummary, 0, len(repos))
+	for _, ra := range repos {
+		status := ""
+		if st := ra.Repo.Status(); st != nil {
+			status = *st
+		}
+		out = append(out, AdminAccountSummary{
+			Did:       ra.Repo.Did,
+			Handle:    ra.Actor.Handle,
+			Email:     ra.Repo.Email,
+			Active:    ra.Repo.Active(),
+			Status:    status,
+			CreatedAt: ra.Repo.CreatedAt.Format(time.RFC3339),
+		})
+	}
+
+	return e.JSON(200, out)
+}
+
+// handleAdminAccount returns the detailed record for a single DID.
+func (s *Server) handleAdminAccount(e echo.Context) error {
+	ctx := e.Request().Context()
+
+	did := e.QueryParam("did")
+	if did == "" {
+		return helpers.InputError(e, to.StringPtr("did is required"))
+	}
+
+	ra, err := s.getRepoActorByDid(ctx, did)
+	if err != nil {
+		return helpers.InputError(e, to.StringPtr("unable to find actor"))
+	}
+
+	status := ""
+	if st := ra.Repo.Status(); st != nil {
+		status = *st
+	}
+
+	return e.JSON(200, AdminAccountDetail{
+		Did:            ra.Repo.Did,
+		Handle:         ra.Actor.Handle,
+		Email:          ra.Repo.Email,
+		EmailConfirmed: ra.Repo.EmailConfirmedAt != nil,
+		Active:         ra.Repo.Active(),
+		Status:         status,
+		TwoFactorType:  string(ra.Repo.TwoFactorType),
+		CreatedAt:      ra.Repo.CreatedAt.Format(time.RFC3339),
+		Rev:            ra.Repo.Rev,
+	})
+}

--- a/server/handle_admin_accounts_test.go
+++ b/server/handle_admin_accounts_test.go
@@ -1,0 +1,266 @@
+package server
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/haileyok/cocoon/models"
+	"github.com/labstack/echo/v4"
+)
+
+func adminAuthHeader() string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:admin-test-password"))
+}
+
+// callAdminGet drives a middleware-wrapped admin GET endpoint. Empty auth
+// sends no Authorization header.
+func callAdminGet(t *testing.T, s *Server, handler echo.HandlerFunc, target, auth string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	headers := map[string]string{}
+	if auth != "" {
+		headers["Authorization"] = auth
+	}
+	c, rec := newRequestContext(http.MethodGet, target, "", headers)
+
+	h := s.handleAdminMiddleware(handler)
+	if err := h(c); err != nil {
+		c.Error(err)
+	}
+	return rec
+}
+
+// TestAdminAccountsList verifies the list endpoint returns seeded accounts
+// with the documented fields, in a JSON array.
+func TestAdminAccountsList(t *testing.T) {
+	s := newTestServer(t)
+	alice := s.createTestAccount(t, "alice.pds.test")
+	s.createTestAccount(t, "bob.pds.test")
+
+	rec := callAdminGet(t, s, s.handleAdminAccounts, "/admin/accounts", adminAuthHeader())
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d (body %s)", rec.Code, rec.Body.String())
+	}
+
+	var accounts []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &accounts); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(accounts) != 2 {
+		t.Fatalf("expected 2 accounts, got %d", len(accounts))
+	}
+
+	// Ordering is deterministic enough to require the fields; find alice.
+	var found map[string]any
+	for _, a := range accounts {
+		if a["handle"] == alice.Handle {
+			found = a
+		}
+	}
+	if found == nil {
+		t.Fatalf("alice not in list: %s", rec.Body.String())
+	}
+	for _, key := range []string{"did", "handle", "email", "active", "status", "createdAt"} {
+		if _, ok := found[key]; !ok {
+			t.Fatalf("expected key %q in %v", key, found)
+		}
+	}
+	if found["did"] != alice.Did {
+		t.Fatalf("expected did %q, got %v", alice.Did, found["did"])
+	}
+	if found["email"] != alice.Email {
+		t.Fatalf("expected email %q, got %v", alice.Email, found["email"])
+	}
+	if found["active"] != true {
+		t.Fatalf("expected active true, got %v", found["active"])
+	}
+	if found["status"] != nil && found["status"] != "" {
+		t.Fatalf("expected empty status, got %v", found["status"])
+	}
+}
+
+// TestAdminAccountsListPagination verifies limit and offset behave.
+func TestAdminAccountsListPagination(t *testing.T) {
+	s := newTestServer(t)
+	s.createTestAccount(t, "alice.pds.test")
+	s.createTestAccount(t, "bob.pds.test")
+	s.createTestAccount(t, "carol.pds.test")
+
+	names := func(rec *httptest.ResponseRecorder) []string {
+		t.Helper()
+		var accounts []map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &accounts); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		out := []string{}
+		for _, a := range accounts {
+			out = append(out, a["handle"].(string))
+		}
+		return out
+	}
+
+	rec := callAdminGet(t, s, s.handleAdminAccounts, "/admin/accounts?limit=1", adminAuthHeader())
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if got := names(rec); len(got) != 1 {
+		t.Fatalf("expected 1 account with limit=1, got %d (%v)", len(got), got)
+	}
+
+	all := names(callAdminGet(t, s, s.handleAdminAccounts, "/admin/accounts", adminAuthHeader()))
+	if len(all) != 3 {
+		t.Fatalf("expected 3 accounts, got %v", all)
+	}
+
+	skipped := names(callAdminGet(t, s, s.handleAdminAccounts, "/admin/accounts?limit=1&offset=1", adminAuthHeader()))
+	if len(skipped) != 1 || skipped[0] != all[1] {
+		t.Fatalf("expected offset=1 to skip first account: all=%v skipped=%v", all, skipped)
+	}
+}
+
+// TestAdminAccountsListAuthRejection verifies missing/wrong Basic auth is a
+// 400 InputError per handleAdminMiddleware's existing behavior.
+func TestAdminAccountsListAuthRejection(t *testing.T) {
+	s := newTestServer(t)
+	s.createTestAccount(t, "alice.pds.test")
+
+	for name, auth := range map[string]string{
+		"missing auth":   "",
+		"wrong password": "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:nope")),
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := callAdminGet(t, s, s.handleAdminAccounts, "/admin/accounts", auth)
+			if rec.Code != 400 {
+				t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestAdminAccountsListInvalidParams verifies negative limit/offset are input
+// errors, not 500s.
+func TestAdminAccountsListInvalidParams(t *testing.T) {
+	s := newTestServer(t)
+
+	for _, target := range []string{"/admin/accounts?limit=-1", "/admin/accounts?offset=-5", "/admin/accounts?limit=abc"} {
+		t.Run(target, func(t *testing.T) {
+			rec := callAdminGet(t, s, s.handleAdminAccounts, target, adminAuthHeader())
+			if rec.Code != 400 {
+				t.Fatalf("expected 400 for %s, got %d (body %s)", target, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestAdminAccountDetail verifies the detail endpoint returns the full record
+// including derived active/status, for a known DID.
+func TestAdminAccountDetail(t *testing.T) {
+	s := newTestServer(t)
+	alice := s.createTestAccount(t, "alice.pds.test")
+
+	// set email confirmed so the derived field is observable
+	now := time.Now()
+	if err := s.db.Exec(t.Context(), "UPDATE repos SET email_confirmed_at = ? WHERE did = ?", nil, now, alice.Did).Error; err != nil {
+		t.Fatalf("set email confirmed: %v", err)
+	}
+
+	rec := callAdminGet(t, s, s.handleAdminAccount, "/admin/account?did="+alice.Did, adminAuthHeader())
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d (body %s)", rec.Code, rec.Body.String())
+	}
+
+	var acct map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &acct); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if acct["did"] != alice.Did {
+		t.Fatalf("expected did %q, got %v", alice.Did, acct["did"])
+	}
+	if acct["handle"] != alice.Handle {
+		t.Fatalf("expected handle %q, got %v", alice.Handle, acct["handle"])
+	}
+	if acct["email"] != alice.Email {
+		t.Fatalf("expected email %q, got %v", alice.Email, acct["email"])
+	}
+	if acct["emailConfirmed"] != true {
+		t.Fatalf("expected emailConfirmed true, got %v", acct["emailConfirmed"])
+	}
+	if acct["active"] != true {
+		t.Fatalf("expected active true, got %v", acct["active"])
+	}
+	if acct["twoFactorType"] != string(models.TwoFactorTypeNone) {
+		t.Fatalf("expected twoFactorType %q, got %v", models.TwoFactorTypeNone, acct["twoFactorType"])
+	}
+	for _, key := range []string{"status", "createdAt", "rev"} {
+		if _, ok := acct[key]; !ok {
+			t.Fatalf("expected key %q in %v", key, acct)
+		}
+	}
+}
+
+// TestAdminAccountDetailStatusDerived verifies a deactivated repo reports
+// status "deactivated" and active false.
+func TestAdminAccountDetailStatusDerived(t *testing.T) {
+	s := newTestServer(t)
+	alice := s.createTestAccount(t, "alice.pds.test")
+
+	if err := s.db.Exec(t.Context(), "UPDATE repos SET deactivated = true WHERE did = ?", nil, alice.Did).Error; err != nil {
+		t.Fatalf("deactivate repo: %v", err)
+	}
+
+	rec := callAdminGet(t, s, s.handleAdminAccount, "/admin/account?did="+alice.Did, adminAuthHeader())
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d (body %s)", rec.Code, rec.Body.String())
+	}
+
+	var acct map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &acct); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if acct["status"] != "deactivated" {
+		t.Fatalf("expected status deactivated, got %v", acct["status"])
+	}
+	if acct["active"] != false {
+		t.Fatalf("expected active false, got %v", acct["active"])
+	}
+}
+
+// TestAdminAccountDetailErrors verifies unknown DID, missing did param, and
+// auth rejection.
+func TestAdminAccountDetailErrors(t *testing.T) {
+	s := newTestServer(t)
+	alice := s.createTestAccount(t, "alice.pds.test")
+
+	t.Run("unknown did", func(t *testing.T) {
+		rec := callAdminGet(t, s, s.handleAdminAccount, "/admin/account?did=did:plc:doesnotexistaaaaaaaaaaa", adminAuthHeader())
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("missing did", func(t *testing.T) {
+		rec := callAdminGet(t, s, s.handleAdminAccount, "/admin/account", adminAuthHeader())
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("invalid did", func(t *testing.T) {
+		rec := callAdminGet(t, s, s.handleAdminAccount, "/admin/account?did=not-a-did", adminAuthHeader())
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("missing auth", func(t *testing.T) {
+		rec := callAdminGet(t, s, s.handleAdminAccount, "/admin/account?did="+alice.Did, "")
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+	})
+}

--- a/server/handle_admin_oauth_authorize.go
+++ b/server/handle_admin_oauth_authorize.go
@@ -86,10 +86,19 @@ func (s *Server) handleAdminOauthAuthorize(e echo.Context) error {
 
 	code := oauth.GenerateCode()
 
-	if err := s.db.Exec(ctx, "UPDATE oauth_authorization_requests SET sub = ?, code = ?, accepted = ?, ip = ? WHERE request_id = ?", nil, repo.Repo.Did, code, true, e.RealIP(), reqId).Error; err != nil {
-		logger.Error("error updating authorization request", "error", err)
+	// Guard the UPDATE with sub/code IS NULL so two concurrent admin calls
+	// cannot both mint codes for the same pending request; the loser gets the
+	// same already-authorized error the pre-check produces.
+	res := s.db.Exec(ctx, "UPDATE oauth_authorization_requests SET sub = ?, code = ?, accepted = ?, ip = ? WHERE request_id = ? AND sub IS NULL AND code IS NULL", nil, repo.Repo.Did, code, true, e.RealIP(), reqId)
+	if res.Error != nil {
+		logger.Error("error updating authorization request", "error", res.Error)
 		return helpers.ServerError(e, nil)
 	}
+	if res.RowsAffected == 0 {
+		return helpers.InputError(e, to.StringPtr("this request was already authorized"))
+	}
+
+	logger.Info("admin-minted oauth authorization", "request_id", reqId, "client_id", authReq.ClientId, "sub", repo.Repo.Did, "ip", e.RealIP())
 
 	return e.JSON(200, AdminOauthAuthorizeResponse{
 		Code:        code,

--- a/server/handle_admin_oauth_authorize.go
+++ b/server/handle_admin_oauth_authorize.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"time"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/haileyok/cocoon/internal/helpers"
+	"github.com/haileyok/cocoon/oauth"
+	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/labstack/echo/v4"
+)
+
+// Admin-minted OAuth authorization.
+//
+// This endpoint exists so an operator (or an agent acting with operator
+// authority) can complete the consent step of the atproto OAuth flow without a
+// browser: instead of an HTML cookie session clicking "Accept" on
+// /oauth/authorize, the admin supplies a pending PAR request_uri plus the DID
+// of the account being authorized. It performs exactly what the human consent
+// path performs (mints a code, persists sub/code/accepted) and nothing more:
+// all client-side binding — DPoP jkt and PKCE verification — is still enforced
+// at /oauth/token, untouched. The admin can authorize any account's grant;
+// that is the intended operator-owns-everything model for self-hosted
+// single-operator PDSes.
+//
+// This is a plain /admin/* route (Basic auth via handleAdminMiddleware, the
+// same gate as the admin invite-code XRPCs) rather than an XRPC, because
+// com.atproto.* is the protocol-owned namespace and this is a management
+// operation, not a protocol one.
+type AdminOauthAuthorizeRequest struct {
+	RequestUri string `json:"requestUri" validate:"required"`
+	Did        string `json:"did" validate:"required,atproto-did"`
+}
+
+type AdminOauthAuthorizeResponse struct {
+	Code        string `json:"code"`
+	State       string `json:"state"`
+	RedirectUri string `json:"redirectUri"`
+	Iss         string `json:"iss"`
+}
+
+func (s *Server) handleAdminOauthAuthorize(e echo.Context) error {
+	ctx := e.Request().Context()
+	logger := s.logger.With("name", "handleAdminOauthAuthorize")
+
+	var req AdminOauthAuthorizeRequest
+	if err := e.Bind(&req); err != nil {
+		logger.Error("error binding request", "error", err)
+		return helpers.InputError(e, nil)
+	}
+
+	if err := e.Validate(req); err != nil {
+		logger.Error("error validating request", "error", err)
+		return helpers.InputError(e, nil)
+	}
+
+	reqId, err := oauth.DecodeRequestUri(req.RequestUri)
+	if err != nil {
+		return helpers.InputError(e, to.StringPtr(err.Error()))
+	}
+
+	var authReq provider.OauthAuthorizationRequest
+	if err := s.db.Raw(ctx, "SELECT * FROM oauth_authorization_requests WHERE request_id = ?", nil, reqId).Scan(&authReq).Error; err != nil {
+		return helpers.ServerError(e, to.StringPtr(err.Error()))
+	}
+	if authReq.RequestId == "" {
+		return helpers.InputError(e, to.StringPtr("no authorization request found for the supplied request uri"))
+	}
+
+	if time.Now().After(authReq.ExpiresAt) {
+		return helpers.InputError(e, to.StringPtr("the request has expired"))
+	}
+
+	if authReq.Sub != nil || authReq.Code != nil {
+		return helpers.InputError(e, to.StringPtr("this request was already authorized"))
+	}
+
+	// Unlike the human consent path we deliberately do not look the client up
+	// here: the token endpoint re-authenticates the client on exchange, and
+	// admin Basic auth is the authority boundary for this endpoint.
+
+	repo, err := s.getRepoActorByDid(ctx, req.Did)
+	if err != nil {
+		return helpers.InputError(e, to.StringPtr("unable to find actor"))
+	}
+
+	code := oauth.GenerateCode()
+
+	if err := s.db.Exec(ctx, "UPDATE oauth_authorization_requests SET sub = ?, code = ?, accepted = ?, ip = ? WHERE request_id = ?", nil, repo.Repo.Did, code, true, e.RealIP(), reqId).Error; err != nil {
+		logger.Error("error updating authorization request", "error", err)
+		return helpers.ServerError(e, nil)
+	}
+
+	return e.JSON(200, AdminOauthAuthorizeResponse{
+		Code:        code,
+		State:       authReq.Parameters.State,
+		RedirectUri: authReq.Parameters.RedirectURI,
+		Iss:         "https://" + s.config.Hostname,
+	})
+}

--- a/server/handle_admin_oauth_authorize_test.go
+++ b/server/handle_admin_oauth_authorize_test.go
@@ -1,0 +1,389 @@
+package server
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/haileyok/cocoon/internal/helpers"
+	"github.com/haileyok/cocoon/oauth"
+	"github.com/haileyok/cocoon/oauth/provider"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+)
+
+// RFC 7636 appendix B test vector (S256).
+const (
+	pkceVerifier  = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	pkceChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+)
+
+// newTestDpopProofForKey signs a DPoP proof JWT with the provided ES256 key
+// (same shape as newTestDpopProof, but the key is supplied so the caller can
+// also compute its JKT).
+func newTestDpopProofForKey(t *testing.T, s *Server, priv *ecdsa.PrivateKey, method, htu string, accessToken *string) string {
+	t.Helper()
+
+	pub, err := jwk.FromRaw(priv.Public())
+	if err != nil {
+		t.Fatalf("build public jwk: %v", err)
+	}
+	pubBytes, err := json.Marshal(pub)
+	if err != nil {
+		t.Fatalf("marshal public jwk: %v", err)
+	}
+	var jwkMap map[string]any
+	if err := json.Unmarshal(pubBytes, &jwkMap); err != nil {
+		t.Fatalf("unmarshal public jwk: %v", err)
+	}
+
+	claims := map[string]any{
+		"iat":   time.Now().Unix(),
+		"jti":   helpers.RandomVarchar(20),
+		"htm":   method,
+		"htu":   htu,
+		"nonce": s.oauthProvider.NextNonce(),
+	}
+	if accessToken != nil {
+		sum := sha256.Sum256([]byte(*accessToken))
+		claims["ath"] = base64.RawURLEncoding.EncodeToString(sum[:])
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims(claims))
+	token.Header["typ"] = "dpop+jwt"
+	token.Header["jwk"] = jwkMap
+	signed, err := token.SignedString(priv)
+	if err != nil {
+		t.Fatalf("sign dpop proof: %v", err)
+	}
+	return signed
+}
+
+// newTestDpopProofWithJkt is newTestDpopProof extended to also return the
+// proof key's JKT (RFC 9449 thumbprint), so a PAR row can be seeded with the
+// matching dpop_jkt.
+func newTestDpopProofWithJkt(t *testing.T, s *Server, method, htu string) (string, string) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate dpop key: %v", err)
+	}
+
+	proof := newTestDpopProofForKey(t, s, priv, method, htu, nil)
+
+	pub, err := jwk.FromRaw(priv.Public())
+	if err != nil {
+		t.Fatalf("build public jwk: %v", err)
+	}
+	thumbBytes, err := pub.Thumbprint(crypto.SHA256)
+	if err != nil {
+		t.Fatalf("thumbprint: %v", err)
+	}
+
+	return proof, base64.RawURLEncoding.EncodeToString(thumbBytes)
+}
+
+// seedPendingAuthRequest inserts a pending (not yet authorized) PAR row for
+// the given subject DID, with PKCE and DPoP binding, returning its request_uri.
+func seedPendingAuthRequest(t *testing.T, s *Server, did, dpopJkt string, expiresAt time.Time) string {
+	t.Helper()
+
+	authReq := provider.OauthAuthorizationRequest{
+		RequestId: "req-" + helpers.RandomVarchar(8),
+		ClientId:  "http://localhost",
+		Parameters: provider.ParRequest{
+			AuthenticateClientRequestBase: provider.AuthenticateClientRequestBase{ClientID: "http://localhost"},
+			ResponseType:                  "code",
+			RedirectURI:                   "http://127.0.0.1/",
+			State:                         "state-admin-1",
+			Scope:                         "atproto",
+			CodeChallenge:                 to.StringPtr(pkceChallenge),
+			CodeChallengeMethod:           "S256",
+			DpopJkt:                       to.StringPtr(dpopJkt),
+		},
+		ExpiresAt: expiresAt,
+	}
+	if err := s.db.Create(context.Background(), &authReq, nil).Error; err != nil {
+		t.Fatalf("seed authorization request: %v", err)
+	}
+	return oauth.EncodeRequestUri(authReq.RequestId)
+}
+
+// callAdminAuthorize drives the middleware-wrapped admin authorize endpoint
+// (Basic auth lives in handleAdminMiddleware, so the chain must be exercised,
+// not the bare handler). Empty user/pass sends no Authorization header.
+func callAdminAuthorize(t *testing.T, s *Server, body, user, pass string) (*httptest.ResponseRecorder, map[string]string) {
+	t.Helper()
+
+	headers := map[string]string{}
+	if user != "" || pass != "" {
+		headers["Authorization"] = "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+	}
+	c, rec := newRequestContext(http.MethodPost, "/admin/oauth/authorize", body, headers)
+
+	h := s.handleAdminMiddleware(s.handleAdminOauthAuthorize)
+	if err := h(c); err != nil {
+		c.Error(err)
+	}
+
+	var resp map[string]string
+	if rec.Body.Len() > 0 {
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response body %q: %v", rec.Body.String(), err)
+		}
+	}
+	return rec, resp
+}
+
+// TestAdminOauthAuthorizeHappyPath verifies that valid admin Basic auth
+// completes a pending PAR request for an existing DID: the response code
+// matches the persisted row, sub equals the DID, and accepted is set.
+func TestAdminOauthAuthorizeHappyPath(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+
+	requestUri := seedPendingAuthRequest(t, s, acct.Did, "", time.Now().Add(time.Hour))
+
+	body, err := json.Marshal(map[string]string{"requestUri": requestUri, "did": acct.Did})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, resp := callAdminAuthorize(t, s, string(body), "admin", "admin-test-password")
+
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d (body %s)", rec.Code, rec.Body.String())
+	}
+	if resp["code"] == "" {
+		t.Fatal("expected non-empty code in response")
+	}
+	if resp["state"] != "state-admin-1" {
+		t.Fatalf("expected state %q, got %q", "state-admin-1", resp["state"])
+	}
+	if resp["redirectUri"] != "http://127.0.0.1/" {
+		t.Fatalf("expected redirectUri %q, got %q", "http://127.0.0.1/", resp["redirectUri"])
+	}
+	if resp["iss"] != "https://"+testHostname {
+		t.Fatalf("expected iss %q, got %q", "https://"+testHostname, resp["iss"])
+	}
+
+	var row provider.OauthAuthorizationRequest
+	if err := s.db.Raw(context.Background(), "SELECT * FROM oauth_authorization_requests WHERE request_id = ?", nil, decodeReqUri(t, requestUri)).Scan(&row).Error; err != nil {
+		t.Fatalf("load row: %v", err)
+	}
+	if row.Sub == nil || *row.Sub != acct.Did {
+		t.Fatalf("expected sub %q, got %v", acct.Did, row.Sub)
+	}
+	if row.Code == nil || *row.Code != resp["code"] {
+		t.Fatalf("expected persisted code %q, got %v", resp["code"], row.Code)
+	}
+	if row.Accepted == nil || !*row.Accepted {
+		t.Fatal("expected accepted to be set true")
+	}
+}
+
+func decodeReqUri(t *testing.T, requestUri string) string {
+	t.Helper()
+	id, err := oauth.DecodeRequestUri(requestUri)
+	if err != nil {
+		t.Fatalf("decode request uri: %v", err)
+	}
+	return id
+}
+
+// TestAdminOauthAuthorizeExchange proves the full headless loop: a code minted
+// by the admin endpoint exchanges at /oauth/token with DPoP + PKCE for tokens
+// whose sub is the requested DID.
+func TestAdminOauthAuthorizeExchange(t *testing.T) {
+	s := newTestServer(t)
+	attachOauthProvider(t, s)
+	acct := s.createTestAccount(t, "bob.pds.test")
+
+	proof, jkt := newTestDpopProofWithJkt(t, s, http.MethodPost, "https://"+testHostname+"/oauth/token")
+	requestUri := seedPendingAuthRequest(t, s, acct.Did, jkt, time.Now().Add(time.Hour))
+
+	body, err := json.Marshal(map[string]string{"requestUri": requestUri, "did": acct.Did})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, resp := callAdminAuthorize(t, s, string(body), "admin", "admin-test-password")
+	if rec.Code != 200 {
+		t.Fatalf("expected 200 from admin authorize, got %d (body %s)", rec.Code, rec.Body.String())
+	}
+
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {"http://localhost"},
+		"code":          {resp["code"]},
+		"redirect_uri":  {"http://127.0.0.1/"},
+		"code_verifier": {pkceVerifier},
+	}
+	c, trec := newRequestContext(http.MethodPost, "/oauth/token", form.Encode(), map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+		"DPoP":         proof,
+	})
+	if err := s.handleOauthToken(c); err != nil {
+		c.Error(err)
+	}
+
+	if trec.Code != 200 {
+		t.Fatalf("expected 200 from token exchange, got %d (body %s)", trec.Code, trec.Body.String())
+	}
+
+	var tokResp OauthTokenResponse
+	if err := json.Unmarshal(trec.Body.Bytes(), &tokResp); err != nil {
+		t.Fatalf("decode token response: %v", err)
+	}
+	if tokResp.Sub != acct.Did {
+		t.Fatalf("expected sub %q, got %q", acct.Did, tokResp.Sub)
+	}
+	if tokResp.AccessToken == "" || tokResp.RefreshToken == "" {
+		t.Fatal("expected non-empty access and refresh tokens")
+	}
+	if tokResp.TokenType != "DPoP" {
+		t.Fatalf("expected DPoP token type, got %q", tokResp.TokenType)
+	}
+}
+
+// TestAdminOauthAuthorizeAuthRejection verifies wrong and missing Basic auth
+// are both rejected (HTTP 400 per handleAdminMiddleware's existing behavior).
+func TestAdminOauthAuthorizeAuthRejection(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "carol.pds.test")
+	requestUri := seedPendingAuthRequest(t, s, acct.Did, "", time.Now().Add(time.Hour))
+
+	body, err := json.Marshal(map[string]string{"requestUri": requestUri, "did": acct.Did})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		user string
+		pass string
+	}{
+		{name: "wrong password", user: "admin", pass: "wrong"},
+		{name: "wrong user", user: "root", pass: "admin-test-password"},
+		{name: "missing auth", user: "", pass: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, resp := callAdminAuthorize(t, s, string(body), tc.user, tc.pass)
+			if rec.Code != 400 {
+				t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+			}
+			if resp["error"] != "Unauthorized" {
+				t.Fatalf("expected error Unauthorized, got %q", resp["error"])
+			}
+		})
+	}
+
+	// A rejected call must not have authorized the pending request.
+	var row provider.OauthAuthorizationRequest
+	if err := s.db.Raw(context.Background(), "SELECT * FROM oauth_authorization_requests WHERE request_id = ?", nil, decodeReqUri(t, requestUri)).Scan(&row).Error; err != nil {
+		t.Fatalf("load row: %v", err)
+	}
+	if row.Code != nil {
+		t.Fatal("expected no code minted for unauthenticated call")
+	}
+}
+
+// TestAdminOauthAuthorizeNegatives covers expired, already-authorized,
+// unknown-DID, malformed-requestUri, invalid-DID, and unknown-request cases.
+func TestAdminOauthAuthorizeNegatives(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "dave.pds.test")
+
+	const admin = "admin"
+	const pass = "admin-test-password"
+
+	t.Run("expired request", func(t *testing.T) {
+		requestUri := seedPendingAuthRequest(t, s, acct.Did, "", time.Now().Add(-time.Minute))
+		body, _ := json.Marshal(map[string]string{"requestUri": requestUri, "did": acct.Did})
+		rec, resp := callAdminAuthorize(t, s, string(body), admin, pass)
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+		if resp["error"] != "the request has expired" {
+			t.Fatalf("expected expiry error, got %q", resp["error"])
+		}
+	})
+
+	t.Run("already authorized", func(t *testing.T) {
+		requestUri := seedPendingAuthRequest(t, s, acct.Did, "", time.Now().Add(time.Hour))
+		// authorize once
+		body, _ := json.Marshal(map[string]string{"requestUri": requestUri, "did": acct.Did})
+		rec, _ := callAdminAuthorize(t, s, string(body), admin, pass)
+		if rec.Code != 200 {
+			t.Fatalf("setup: expected 200, got %d", rec.Code)
+		}
+		// authorize again
+		rec, resp := callAdminAuthorize(t, s, string(body), admin, pass)
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+		if resp["error"] != "this request was already authorized" {
+			t.Fatalf("expected already-authorized error, got %q", resp["error"])
+		}
+	})
+
+	t.Run("unknown did", func(t *testing.T) {
+		requestUri := seedPendingAuthRequest(t, s, acct.Did, "", time.Now().Add(time.Hour))
+		body, _ := json.Marshal(map[string]string{"requestUri": requestUri, "did": "did:plc:doesnotexistaaaaaaaaaaa"})
+		rec, resp := callAdminAuthorize(t, s, string(body), admin, pass)
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+		if resp["error"] != "unable to find actor" {
+			t.Fatalf("expected unknown-actor error, got %q", resp["error"])
+		}
+	})
+
+	t.Run("unparseable request uri", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]string{"requestUri": "not-a-request-uri", "did": acct.Did})
+		rec, resp := callAdminAuthorize(t, s, string(body), admin, pass)
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+		if resp["error"] == "" || resp["error"] == "InvalidRequest" {
+			t.Fatalf("expected specific decode error, got %q", resp["error"])
+		}
+	})
+
+	t.Run("invalid did format", func(t *testing.T) {
+		requestUri := seedPendingAuthRequest(t, s, acct.Did, "", time.Now().Add(time.Hour))
+		body, _ := json.Marshal(map[string]string{"requestUri": requestUri, "did": "not-a-did"})
+		rec, _ := callAdminAuthorize(t, s, string(body), admin, pass)
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("unknown request", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]string{"requestUri": oauth.EncodeRequestUri("req-doesnotexist"), "did": acct.Did})
+		rec, resp := callAdminAuthorize(t, s, string(body), admin, pass)
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+		if resp["error"] == "" {
+			t.Fatal("expected an error message")
+		}
+	})
+
+	t.Run("missing fields", func(t *testing.T) {
+		rec, _ := callAdminAuthorize(t, s, `{}`, admin, pass)
+		if rec.Code != 400 {
+			t.Fatalf("expected 400, got %d (body %s)", rec.Code, rec.Body.String())
+		}
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -592,6 +592,9 @@ func (s *Server) addRoutes() {
 	// admin routes
 	s.echo.POST("/xrpc/com.atproto.server.createInviteCode", s.handleCreateInviteCode, s.handleAdminMiddleware)
 	s.echo.POST("/xrpc/com.atproto.server.createInviteCodes", s.handleCreateInviteCodes, s.handleAdminMiddleware)
+	s.echo.POST("/admin/oauth/authorize", s.handleAdminOauthAuthorize, s.handleAdminMiddleware)
+	s.echo.GET("/admin/accounts", s.handleAdminAccounts, s.handleAdminMiddleware)
+	s.echo.GET("/admin/account", s.handleAdminAccount, s.handleAdminMiddleware)
 
 	// are there any routes that we should be allowing without auth? i dont think so but idk
 	s.echo.GET("/xrpc/*", s.handleProxy, s.handleLegacySessionMiddleware, s.handleOauthSessionMiddleware)


### PR DESCRIPTION
## Summary
- Add a headless agent path for Cocoon: an admin-minted OAuth consent endpoint, admin account-visibility endpoints, machine-parseable CLI output, and a complete agent runbook — so an autonomous agent can deploy a PDS, provision an account, get tokens, and manage the service with no browser.
- All human-facing flows (HTML sign-in, compose quickstart, CLI prose output) are unchanged.

## Changes
- **`POST /admin/oauth/authorize`** (new `server/handle_admin_oauth_authorize.go`): admin Basic auth completes a pending PAR request for a given DID, returning `{code, state, redirectUri, iss}`. This replaces the browser consent click with operator authority — intended for self-hosted single-operator PDSes where the operator owns the accounts. DPoP `jkt` and PKCE binding at `/oauth/token` are untouched; the minted code exchanges through the standard machinery. The UPDATE is guarded against concurrent double-minting (`sub/code IS NULL` + `RowsAffected` check) and logs an audit line on success.
- **`GET /admin/accounts`** and **`GET /admin/account?did=`** (new `server/handle_admin_accounts.go`): account list (limit default 100 / cap 500, offset paging, deterministic ordering) and per-DID detail, both exposing derived `active`/`status`. Same `handleAdminMiddleware` Basic-auth gate as the existing admin invite XRPCs. Plain `/admin/*` routes rather than XRPC NSIDs, since `com.atproto.*` is the protocol-owned namespace.
- **CLI `--json`** on `create-invite-code` (`{"code","uses","for"}`), `reset-password` (`{"did","password"}`), and `recommit-repos` (per-DID result array; banners and the migration logger go to real stderr so stdout is pure JSON). Output is routed through `App.Writer` via a new package-level `newApp()`; without `--json`, output is byte-identical to before. `create-initial-invite.sh` is untouched.
- **`docs/agent-setup.md`**: eight-section agent runbook (deploy → invite code → createAccount → session tokens → first write → full OAuth client flow with the admin-minted consent step → manage → troubleshooting), linked from a short "For agents" section at the top of `README.md`.
- **`server/docs_contract_test.go`**: every documented route must appear in the runbook and be registered on the router (both directions), plus section-heading and README-link assertions.

## Validation
- `gofmt -l .` clean; `go vet ./...` clean.
- `go test ./...` green; `go test -race ./...` green (CGO on; commands run with `TMPDIR=$HOME/.gotmp` due to a local /tmp quota, not a repo issue).
- New tests: 16 admin-authorize cases including the repo's **first happy-path authorization_code exchange** (real DPoP proof + RFC 7636 PKCE test vector, asserting DPoP-bound tokens with the correct `sub`); 6 admin-accounts tests (list, pagination, detail, derived status, auth rejection, invalid params); 7 CLI tests (JSON shape, legacy prose byte-identity, DB cross-checks, stdout purity under production writer wiring).
- Independent model review of the completed work verified: DPoP/PKCE binding not weakened, all new routes gated, no query injection, no secret leakage in `--json`; all must-fix and low findings addressed (commits c12f24f + aab7928).

## Review notes
- The admin-minted authorize endpoint lets the admin authorize **any** account's OAuth grant by design (operator-owns-everything trust model, stated plainly in the runbook). Do not use on a PDS with untrusted account owners.
- PAR requests expire (on the order of minutes) — the admin consent step must follow PAR promptly; documented and test-covered.
- Pre-existing, out of scope: `handleAdminMiddleware` returns 400 (not 401) for bad Basic auth and compares the password non-constant-time; no rate limiting on admin auth. The runbook documents the 400. Worth a follow-up issue if this surface grows.
- Docs contract test uses substring matching for route mentions — catches renames and omissions, but not every prose drift; accepted.
