### PR TITLE
Enforce endpoint authorization for OAuth and service credentials

### DIFF
--- a/oauth/scopes/parser.go
+++ b/oauth/scopes/parser.go
@@ -7,6 +7,7 @@ package scopes
 
 import (
 	"fmt"
+	"mime"
 	"net/url"
 	"strings"
 
@@ -209,7 +210,35 @@ func parseBlob(raw, positional string, hasPositional bool, params url.Values) (*
 	if len(accept) == 0 {
 		return nil, fmt.Errorf("blob scope %q requires an accept pattern", raw)
 	}
+	for i, pattern := range accept {
+		normalized, err := normalizeMIMEPattern(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("blob scope %q has invalid accept pattern %q: %w", raw, pattern, err)
+		}
+		accept[i] = normalized
+	}
 	return &Scope{Raw: raw, Resource: ResourceBlob, Accept: accept}, nil
+}
+
+func normalizeMIMEPattern(pattern string) (string, error) {
+	mediaType, params, err := mime.ParseMediaType(pattern)
+	if err != nil {
+		return "", err
+	}
+	if len(params) != 0 {
+		return "", fmt.Errorf("parameters are not allowed")
+	}
+
+	parts := strings.Split(mediaType, "/")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("must contain one type/subtype separator")
+	}
+	if strings.Contains(mediaType, "*") && mediaType != "*/*" {
+		if parts[1] != "*" || strings.Contains(parts[0], "*") {
+			return "", fmt.Errorf("wildcards must be type/* or */*")
+		}
+	}
+	return strings.ToLower(mediaType), nil
 }
 
 func parseAccount(raw, positional string, hasPositional bool, params url.Values) (*Scope, error) {
@@ -224,10 +253,6 @@ func parseAccount(raw, positional string, hasPositional bool, params url.Values)
 	case "", "read":
 		action = "read"
 	case "manage":
-		// only repo supports manage
-		if positional != "repo" {
-			return nil, fmt.Errorf("account scope %q does not support action=manage", raw)
-		}
 	default:
 		return nil, fmt.Errorf("account scope %q has invalid action %q", raw, action)
 	}
@@ -272,6 +297,37 @@ func (s *Scope) AllowsRepoWrite(collection, action string) bool {
 	}
 	for _, c := range s.Collections {
 		if c == "*" || c == collection {
+			return true
+		}
+	}
+	return false
+}
+
+// AllowsAccount checks attribute access; manage implies read.
+func (s *Scope) AllowsAccount(attr, action string) bool {
+	if s == nil || s.Resource != ResourceAccount || s.Attr != attr {
+		return false
+	}
+	return s.Action == action || (s.Action == "manage" && action == "read")
+}
+
+// AllowsIdentity checks attribute access, including identity:*.
+func (s *Scope) AllowsIdentity(attr string) bool {
+	return s != nil && s.Resource == ResourceIdentity && (s.Attr == "*" || s.Attr == attr)
+}
+
+// AllowsBlob reports whether this scope accepts a concrete MIME type.
+func (s *Scope) AllowsBlob(mediaType string) bool {
+	if s == nil || s.Resource != ResourceBlob {
+		return false
+	}
+	normalized, err := normalizeMIMEPattern(mediaType)
+	if err != nil || strings.Contains(normalized, "*") {
+		return false
+	}
+	typeName := strings.SplitN(normalized, "/", 2)[0]
+	for _, pattern := range s.Accept {
+		if pattern == "*/*" || pattern == normalized || pattern == typeName+"/*" {
 			return true
 		}
 	}

--- a/oauth/scopes/parser_test.go
+++ b/oauth/scopes/parser_test.go
@@ -47,12 +47,20 @@ func TestParseValid(t *testing.T) {
 			&Scope{Raw: "blob:image/*", Resource: ResourceBlob, Accept: []string{"image/*"}},
 		},
 		{
+			"blob:IMAGE/PNG",
+			&Scope{Raw: "blob:IMAGE/PNG", Resource: ResourceBlob, Accept: []string{"image/png"}},
+		},
+		{
 			"account:email",
 			&Scope{Raw: "account:email", Resource: ResourceAccount, Attr: "email", Action: "read"},
 		},
 		{
 			"account:repo?action=manage",
 			&Scope{Raw: "account:repo?action=manage", Resource: ResourceAccount, Attr: "repo", Action: "manage"},
+		},
+		{
+			"account:email?action=manage",
+			&Scope{Raw: "account:email?action=manage", Resource: ResourceAccount, Attr: "email", Action: "manage"},
 		},
 		{
 			"identity:*",
@@ -89,8 +97,12 @@ func TestParseInvalid(t *testing.T) {
 		"include:not_a_valid_nsid",
 		"include:",
 		"account:bogus",
-		"account:email?action=manage",
 		"identity:bogus",
+		"blob:image/p*",
+		"blob:im*age/*",
+		"blob:*/png",
+		"blob:image/png;quality=high",
+		"blob:not-a-mime-type",
 	}
 
 	for _, raw := range invalid {
@@ -137,6 +149,84 @@ func TestAllowsRepoWrite(t *testing.T) {
 			}
 			if got := sc.AllowsRepoWrite(tt.collection, tt.action); got != tt.want {
 				t.Fatalf("AllowsRepoWrite(%q,%q) = %v, want %v", tt.collection, tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllowsAccount(t *testing.T) {
+	tests := []struct {
+		scope, attr, action string
+		want                bool
+	}{
+		{"account:email", "email", "read", true},
+		{"account:email", "email", "manage", false},
+		{"account:email?action=manage", "email", "manage", true},
+		{"account:email?action=manage", "email", "read", true},
+		{"account:email?action=manage", "repo", "read", false},
+		{"account:repo?action=manage", "email", "read", false},
+		{"identity:handle", "email", "read", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.scope+"_"+tt.attr+"_"+tt.action, func(t *testing.T) {
+			sc, err := Parse(tt.scope)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := sc.AllowsAccount(tt.attr, tt.action); got != tt.want {
+				t.Fatalf("AllowsAccount(%q, %q) = %v, want %v", tt.attr, tt.action, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllowsIdentity(t *testing.T) {
+	tests := []struct {
+		scope, attr string
+		want        bool
+	}{
+		{"identity:handle", "handle", true},
+		{"identity:handle", "email", false},
+		{"identity:*", "handle", true},
+		{"identity:*", "anything", true},
+		{"account:email", "email", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.scope+"_"+tt.attr, func(t *testing.T) {
+			sc, err := Parse(tt.scope)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := sc.AllowsIdentity(tt.attr); got != tt.want {
+				t.Fatalf("AllowsIdentity(%q) = %v, want %v", tt.attr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllowsBlob(t *testing.T) {
+	tests := []struct {
+		scope, mediaType string
+		want             bool
+	}{
+		{"blob:image/png", "image/png", true},
+		{"blob:image/png", "IMAGE/PNG", true},
+		{"blob:image/png", "image/jpeg", false},
+		{"blob:image/*", "image/png", true},
+		{"blob:image/*", "video/mp4", false},
+		{"blob:*/*", "application/octet-stream", true},
+		{"blob:*/*", "invalid", false},
+		{"blob:*/*", "image/png; charset=utf-8", false},
+		{"account:email", "image/png", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.scope+"_"+tt.mediaType, func(t *testing.T) {
+			sc, err := Parse(tt.scope)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := sc.AllowsBlob(tt.mediaType); got != tt.want {
+				t.Fatalf("AllowsBlob(%q) = %v, want %v", tt.mediaType, got, tt.want)
 			}
 		})
 	}

--- a/server/endpoint_authorization.go
+++ b/server/endpoint_authorization.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"mime"
+	"net/url"
+	"strings"
+
+	"github.com/haileyok/cocoon/internal/helpers"
+	"github.com/haileyok/cocoon/oauth/scopes"
+	"github.com/labstack/echo/v4"
+)
+
+// credentialKind is set only after credential verification.
+type credentialKind uint8
+
+const (
+	credentialLegacyAccess credentialKind = iota + 1
+	credentialLegacyRefresh
+	credentialOAuth
+	credentialService
+)
+
+// authorizeEndpoint applies endpoint policy after authentication, before handler execution.
+func (s *Server) authorizeEndpoint(e echo.Context, next echo.HandlerFunc) error {
+	kind, ok := e.Get("credentialKind").(credentialKind)
+	if !ok {
+		return helpers.InvalidTokenError(e)
+	}
+	if kind == credentialOAuth {
+		if _, ok := e.Get("scopes").([]string); !ok {
+			return helpers.InvalidTokenError(e)
+		}
+	}
+	nsid := strings.TrimPrefix(e.Request().URL.Path, "/xrpc/")
+	required := ""
+	switch nsid {
+	case "com.atproto.server.requestEmailUpdate", "com.atproto.server.updateEmail",
+		"com.atproto.server.requestAccountDelete", "com.atproto.server.activateAccount", "com.atproto.server.deactivateAccount":
+		if kind != credentialLegacyAccess {
+			return e.JSON(403, map[string]string{"error": "Forbidden", "message": "This endpoint requires a legacy access session"})
+		}
+	case "com.atproto.identity.updateHandle":
+		required = "identity:handle"
+	case "com.atproto.identity.requestPlcOperationSignature", "com.atproto.identity.signPlcOperation", "com.atproto.identity.submitPlcOperation":
+		required = "identity:*"
+	case "com.atproto.repo.importRepo":
+		required = "account:repo?action=manage"
+	case "com.atproto.server.confirmEmail", "com.atproto.server.requestEmailConfirmation":
+		required = "account:email?action=manage"
+	case "com.atproto.repo.uploadBlob":
+		if kind == credentialService {
+			return next(e)
+		}
+		contentType := e.Request().Header.Get("Content-Type")
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil || strings.Count(mediaType, "/") != 1 || strings.Contains(mediaType, "*") {
+			return helpers.InputError(e, nil)
+		}
+		required = "blob:" + strings.ToLower(mediaType)
+	case "app.bsky.actor.getPreferences", "app.bsky.actor.putPreferences":
+		// Local preferences belong to the configured AppView, not the proxy audience.
+		aud := s.config.FallbackProxy
+		selected := e.Request().Header.Get("atproto-proxy")
+		if (kind != credentialLegacyAccess && kind != credentialOAuth) ||
+			(selected != "" && selected != aud) || !s.hasRPCScope(e, aud, nsid) {
+			return helpers.InsufficientScopeError(e, "rpc:"+nsid+"?aud="+url.QueryEscape(aud))
+		}
+	}
+	if required != "" && !s.hasEndpointScope(e, required) {
+		return helpers.InsufficientScopeError(e, required)
+	}
+	return next(e)
+}
+
+func (s *Server) hasEndpointScope(e echo.Context, required string) bool {
+	if e.Get("credentialKind") == credentialLegacyAccess {
+		return true
+	}
+	if e.Get("credentialKind") != credentialOAuth {
+		return false
+	}
+	granted, ok := e.Get("scopes").([]string)
+	if !ok {
+		return false
+	}
+	want, err := scopes.Parse(required)
+	if err != nil {
+		return false
+	}
+	for _, token := range granted {
+		scope, err := scopes.Parse(token)
+		if err != nil {
+			continue
+		}
+		switch want.Resource {
+		case scopes.ResourceAccount:
+			if scope.AllowsAccount(want.Attr, want.Action) ||
+				(token == "transition:email" && want.Attr == "email" && want.Action == "read") {
+				return true
+			}
+		case scopes.ResourceIdentity:
+			if scope.AllowsIdentity(want.Attr) {
+				return true
+			}
+		case scopes.ResourceBlob:
+			if token == "transition:generic" || scope.AllowsBlob(want.Accept[0]) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/server/endpoint_authorization_test.go
+++ b/server/endpoint_authorization_test.go
@@ -1,0 +1,336 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/haileyok/cocoon/models"
+	"github.com/labstack/echo/v4"
+)
+
+type unreadEndpointBody struct{ reads int }
+
+func (b *unreadEndpointBody) Read([]byte) (int, error) { b.reads++; return 0, io.EOF }
+func (b *unreadEndpointBody) Close() error             { return nil }
+
+func endpointTestServer(t *testing.T) (*Server, *testAccount) {
+	t.Helper()
+	s := newTestServer(t)
+	attachOauthProvider(t, s)
+	s.config.FallbackProxy = "did:web:appview.test#view"
+	s.echo = echo.New()
+	s.echo.Validator = newTestValidator()
+	s.addRoutes()
+	return s, s.createTestAccount(t, "endpoint.pds.test")
+}
+
+func TestEndpointAuthorizationDenied(t *testing.T) {
+	for _, tc := range []struct{ method, nsid, scope string }{
+		{"POST", "com.atproto.identity.updateHandle", "atproto"},
+		{"POST", "com.atproto.identity.updateHandle", "transition:generic"},
+		{"POST", "com.atproto.identity.requestPlcOperationSignature", "identity:handle"},
+		{"POST", "com.atproto.identity.signPlcOperation", "identity:handle"},
+		{"POST", "com.atproto.identity.submitPlcOperation", "transition:generic"},
+		{"POST", "com.atproto.repo.importRepo", "account:repo"},
+		{"POST", "com.atproto.repo.importRepo", "transition:generic"},
+		{"POST", "com.atproto.repo.uploadBlob", "blob:video/*"},
+		{"POST", "com.atproto.server.confirmEmail", "account:email"},
+		{"POST", "com.atproto.server.requestEmailConfirmation", "transition:email"},
+		{"POST", "com.atproto.server.requestEmailUpdate", "account:email?action=manage"},
+		{"POST", "com.atproto.server.updateEmail", "transition:generic account:email?action=manage"},
+		{"POST", "com.atproto.server.requestAccountDelete", "account:repo?action=manage"},
+		{"POST", "com.atproto.server.activateAccount", "transition:generic"},
+		{"POST", "com.atproto.server.deactivateAccount", "account:repo?action=manage"},
+		{"GET", "app.bsky.actor.getPreferences", "atproto"},
+		{"POST", "app.bsky.actor.putPreferences", "rpc:app.bsky.actor.getPreferences?aud=did:web:appview.test%23view"},
+	} {
+		t.Run(tc.nsid+"/"+tc.scope, func(t *testing.T) {
+			s, account := endpointTestServer(t)
+			before, err := s.getRepoActorByDid(context.Background(), account.Did)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := &unreadEndpointBody{}
+			r := httptest.NewRequest(tc.method, "/xrpc/"+tc.nsid, nil)
+			r.Body = body
+			r.Header.Set("Content-Type", "image/png")
+			setProxyTestOAuth(t, s, r, account.Did, tc.scope)
+			w := httptest.NewRecorder()
+			s.echo.ServeHTTP(w, r)
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("status %d, want 403", w.Code)
+			}
+			if body.reads != 0 {
+				t.Fatal("denied request body was consumed")
+			}
+			after, err := s.getRepoActorByDid(context.Background(), account.Did)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(before, after) {
+				t.Fatal("denied request mutated the account")
+			}
+		})
+	}
+}
+
+func TestEndpointAuthorizationAllowed(t *testing.T) {
+	for _, tc := range []struct{ method, nsid, scope string }{
+		{"POST", "com.atproto.identity.updateHandle", "identity:handle"},
+		{"POST", "com.atproto.identity.requestPlcOperationSignature", "identity:*"},
+		{"POST", "com.atproto.identity.signPlcOperation", "identity:*"},
+		{"POST", "com.atproto.identity.submitPlcOperation", "identity:*"},
+		{"POST", "com.atproto.repo.importRepo", "account:repo?action=manage"},
+		{"POST", "com.atproto.repo.uploadBlob", "blob:image/*"},
+		{"POST", "com.atproto.server.confirmEmail", "account:email?action=manage"},
+		{"POST", "com.atproto.server.requestEmailConfirmation", "account:email?action=manage"},
+		{"GET", "app.bsky.actor.getPreferences", "rpc:app.bsky.actor.getPreferences?aud=did:web:appview.test%23view"},
+		{"POST", "app.bsky.actor.putPreferences", "transition:generic"},
+		{"GET", "com.atproto.identity.getRecommendedDidCredentials", "atproto"},
+		{"GET", "com.atproto.server.checkAccountStatus", "atproto"},
+		{"GET", "com.atproto.repo.listMissingBlobs", "atproto"},
+	} {
+		t.Run(tc.nsid, func(t *testing.T) {
+			s, account := endpointTestServer(t)
+			// Keep production middleware; stub the handler to isolate authorization.
+			path := "/xrpc/" + tc.nsid
+			s.echo.Add(tc.method, path, func(c echo.Context) error { return c.NoContent(204) }, s.handleLegacySessionMiddleware, s.handleOauthSessionMiddleware)
+			r := httptest.NewRequest(tc.method, path, nil)
+			r.Header.Set("Content-Type", "Image/PNG; charset=utf-8")
+			setProxyTestOAuth(t, s, r, account.Did, tc.scope)
+			w := httptest.NewRecorder()
+			s.echo.ServeHTTP(w, r)
+			if w.Code != 204 {
+				t.Fatalf("permission rejected: %d %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestSessionEmailPermission(t *testing.T) {
+	for _, tc := range []struct {
+		scope string
+		want  bool
+	}{
+		{"atproto", false}, {"transition:generic", false}, {"transition:email", true},
+		{"account:email", true}, {"account:email?action=manage", true}, {"account:repo?action=manage", false},
+		{"legacy", true},
+	} {
+		t.Run(tc.scope, func(t *testing.T) {
+			s, account := endpointTestServer(t)
+			r := httptest.NewRequest("GET", "/xrpc/com.atproto.server.getSession", nil)
+			if tc.scope == "legacy" {
+				repo, err := s.getRepoActorByDid(context.Background(), account.Did)
+				if err != nil {
+					t.Fatal(err)
+				}
+				session, err := s.createSession(context.Background(), &repo.Repo)
+				if err != nil {
+					t.Fatal(err)
+				}
+				r.Header.Set("Authorization", "Bearer "+session.AccessToken)
+			} else {
+				setProxyTestOAuth(t, s, r, account.Did, tc.scope)
+			}
+			w := httptest.NewRecorder()
+			s.echo.ServeHTTP(w, r)
+			if w.Code != 200 {
+				t.Fatalf("getSession: %d", w.Code)
+			}
+			var body map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatal(err)
+			}
+			for _, key := range []string{"email", "emailConfirmed", "emailAuthFactor"} {
+				if _, ok := body[key]; ok != tc.want {
+					t.Fatalf("%s presence = %v, want %v", key, ok, tc.want)
+				}
+			}
+			if tc.want && (body["email"] != account.Email || body["emailConfirmed"] != false || body["emailAuthFactor"] != false) {
+				t.Fatal("email fields changed, including false values")
+			}
+			if body["did"] != account.Did {
+				t.Fatal("missing account identity")
+			}
+		})
+	}
+}
+
+func TestEndpointLegacyAndServicePolicy(t *testing.T) {
+	for _, nsid := range []string{
+		"com.atproto.server.requestEmailUpdate", "com.atproto.server.updateEmail",
+		"com.atproto.server.requestAccountDelete", "com.atproto.server.activateAccount", "com.atproto.server.deactivateAccount",
+		"com.atproto.identity.updateHandle", "com.atproto.repo.importRepo", "com.atproto.repo.uploadBlob",
+	} {
+		t.Run(nsid, func(t *testing.T) {
+			s, account := endpointTestServer(t)
+			path := "/xrpc/" + nsid
+			s.echo.POST(path, func(c echo.Context) error { return c.NoContent(204) }, s.handleLegacySessionMiddleware, s.handleOauthSessionMiddleware)
+			repo, err := s.getRepoActorByDid(context.Background(), account.Did)
+			if err != nil {
+				t.Fatal(err)
+			}
+			session, err := s.createSession(context.Background(), &repo.Repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			service := mintServiceAuthToken(t, account.SigningKey, account.Did, testDid, nsid, time.Now().Add(time.Minute))
+			for _, auth := range []string{session.AccessToken, service} {
+				r := httptest.NewRequest("POST", path, strings.NewReader("{}"))
+				r.Header.Set("Authorization", "Bearer "+auth)
+				w := httptest.NewRecorder()
+				s.echo.ServeHTTP(w, r)
+				want := 204
+				if auth == service && nsid != "com.atproto.repo.uploadBlob" {
+					want = 403
+				}
+				if w.Code != want {
+					t.Fatalf("status %d, want %d", w.Code, want)
+				}
+			}
+		})
+	}
+}
+
+func TestEndpointPreferencesAudience(t *testing.T) {
+	for _, tc := range []struct {
+		audience, header string
+		want             int
+	}{
+		{"did:web:appview.test#view", "", 200},
+		{"did:web:appview.test#view", "did:web:appview.test#view", 200},
+		{"did:web:other.test#view", "", 403},
+		{"did:web:other.test#view", "did:web:other.test#view", 403},
+		{"did:web:appview.test#view", "did:web:other.test#view", 403},
+	} {
+		t.Run(tc.audience+"/"+tc.header, func(t *testing.T) {
+			s, account := endpointTestServer(t)
+			r := httptest.NewRequest("GET", "/xrpc/app.bsky.actor.getPreferences", nil)
+			r.Header.Set("atproto-proxy", tc.header)
+			setProxyTestOAuth(t, s, r, account.Did, "rpc:app.bsky.actor.getPreferences?aud="+tc.audience)
+			w := httptest.NewRecorder()
+			s.echo.ServeHTTP(w, r)
+			if w.Code != tc.want {
+				t.Fatalf("status = %d, want %d: %s", w.Code, tc.want, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestEndpointPreferenceWrite(t *testing.T) {
+	s, account := endpointTestServer(t)
+	body := `{"preferences":[{"$type":"app.bsky.actor.defs.adultContentPref","enabled":false}]}`
+	r := httptest.NewRequest("POST", "/xrpc/app.bsky.actor.putPreferences", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	setProxyTestOAuth(t, s, r, account.Did, "rpc:app.bsky.actor.putPreferences?aud=did:web:appview.test%23view")
+	w := httptest.NewRecorder()
+	s.echo.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("preference write: %d %s", w.Code, w.Body.String())
+	}
+	repo, err := s.getRepoActorByDid(context.Background(), account.Did)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got, want any
+	if err := json.Unmarshal(repo.Preferences, &got); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(body), &want); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatal("preferences were not persisted intact")
+	}
+}
+
+func TestEndpointEmailConfirmation(t *testing.T) {
+	for _, code := range []string{"correct-code", "wrong-code"} {
+		t.Run(code, func(t *testing.T) {
+			s, account := endpointTestServer(t)
+			if err := s.db.Exec(context.Background(), "UPDATE repos SET email_verification_code = ?, email_verification_code_expires_at = ? WHERE did = ?", nil, "correct-code", time.Now().Add(time.Hour), account.Did).Error; err != nil {
+				t.Fatal(err)
+			}
+			body, err := json.Marshal(map[string]string{"email": account.Email, "token": code})
+			if err != nil {
+				t.Fatal(err)
+			}
+			r := httptest.NewRequest("POST", "/xrpc/com.atproto.server.confirmEmail", strings.NewReader(string(body)))
+			r.Header.Set("Content-Type", "application/json")
+			setProxyTestOAuth(t, s, r, account.Did, "account:email?action=manage")
+			w := httptest.NewRecorder()
+			s.echo.ServeHTTP(w, r)
+			wantStatus := 200
+			if code != "correct-code" {
+				wantStatus = 400
+			}
+			if w.Code != wantStatus {
+				t.Fatalf("confirmation status = %d, want %d", w.Code, wantStatus)
+			}
+			repo, err := s.getRepoActorByDid(context.Background(), account.Did)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if (repo.EmailConfirmedAt != nil) != (code == "correct-code") {
+				t.Fatal("unexpected confirmation state")
+			}
+			if (repo.EmailVerificationCode == nil) != (code == "correct-code") {
+				t.Fatal("unexpected challenge consumption")
+			}
+		})
+	}
+}
+
+func TestEndpointBlobUpload(t *testing.T) {
+	s, account := endpointTestServer(t)
+	s.repoman = NewRepoMan(s)
+	const payload = "local blob test bytes"
+	r := httptest.NewRequest("POST", "/xrpc/com.atproto.repo.uploadBlob", strings.NewReader(payload))
+	r.Header.Set("Content-Type", "Text/Plain; charset=utf-8")
+	setProxyTestOAuth(t, s, r, account.Did, "blob:text/*")
+	w := httptest.NewRecorder()
+	s.echo.ServeHTTP(w, r)
+	if w.Code != 200 {
+		t.Fatalf("blob upload: %d %s", w.Code, w.Body.String())
+	}
+	var response ComAtprotoRepoUploadBlobResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Blob.Size != len(payload) || response.Blob.Ref.Link == "" {
+		t.Fatal("invalid uploaded blob response")
+	}
+	var parts []models.BlobPart
+	if err := s.db.Client().Find(&parts).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(parts) != 1 || string(parts[0].Data) != payload {
+		t.Fatal("blob payload not stored intact")
+	}
+}
+
+func TestEndpointScopeStateFailsClosed(t *testing.T) {
+	var s Server
+	for _, kind := range []any{nil, credentialOAuth, credentialLegacyRefresh} {
+		for _, state := range []any{nil, "transition:generic", []string{"transition:generic"}} {
+			c, _ := newRequestContext("POST", "/", "", map[string]string{"Authorization": "Bearer unverified"})
+			c.Set("credentialKind", kind)
+			c.Set("scopes", state)
+			if s.hasEndpointScope(c, "account:repo?action=manage") {
+				t.Fatal("invalid state granted account manage")
+			}
+			if kind != credentialOAuth || reflect.TypeOf(state) != reflect.TypeOf([]string{}) {
+				if s.hasRepoScope(c, "app.bsky.feed.post", "create") || s.hasRPCScope(c, "did:web:appview.test#view", "app.bsky.feed.getTimeline") {
+					t.Fatal("unverified or malformed state granted repo/RPC access")
+				}
+			}
+		}
+	}
+}

--- a/server/handle_server_get_session.go
+++ b/server/handle_server_get_session.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/haileyok/cocoon/models"
 	"github.com/labstack/echo/v4"
 )
@@ -8,9 +9,9 @@ import (
 type ComAtprotoServerGetSessionResponse struct {
 	Handle          string  `json:"handle"`
 	Did             string  `json:"did"`
-	Email           string  `json:"email"`
-	EmailConfirmed  bool    `json:"emailConfirmed"`
-	EmailAuthFactor bool    `json:"emailAuthFactor"`
+	Email           *string `json:"email,omitempty"`
+	EmailConfirmed  *bool   `json:"emailConfirmed,omitempty"`
+	EmailAuthFactor *bool   `json:"emailAuthFactor,omitempty"`
 	Active          bool    `json:"active"`
 	Status          *string `json:"status,omitempty"`
 }
@@ -18,13 +19,16 @@ type ComAtprotoServerGetSessionResponse struct {
 func (s *Server) handleGetSession(e echo.Context) error {
 	repo := e.Get("repo").(*models.RepoActor)
 
-	return e.JSON(200, ComAtprotoServerGetSessionResponse{
-		Handle:          repo.Handle,
-		Did:             repo.Repo.Did,
-		Email:           repo.Email,
-		EmailConfirmed:  repo.EmailConfirmedAt != nil,
-		EmailAuthFactor: repo.TwoFactorType != models.TwoFactorTypeNone,
-		Active:          repo.Active(),
-		Status:          repo.Status(),
-	})
+	response := ComAtprotoServerGetSessionResponse{
+		Handle: repo.Handle,
+		Did:    repo.Repo.Did,
+		Active: repo.Active(),
+		Status: repo.Status(),
+	}
+	if s.hasEndpointScope(e, "account:email") {
+		response.Email = &repo.Email
+		response.EmailConfirmed = to.BoolPtr(repo.EmailConfirmedAt != nil)
+		response.EmailAuthFactor = to.BoolPtr(repo.TwoFactorType != models.TwoFactorTypeNone)
+	}
+	return e.JSON(200, response)
 }

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -230,6 +230,13 @@ func (s *Server) handleLegacySessionMiddleware(next echo.HandlerFunc) echo.Handl
 		e.Set("did", did)
 		e.Set("token", tokenstr)
 		e.Set("legacyRefresh", isRefresh)
+		kind := credentialLegacyAccess
+		if isRefresh {
+			kind = credentialLegacyRefresh
+		} else if hasLxm {
+			kind = credentialService
+		}
+		e.Set("credentialKind", kind)
 
 		if err := next(e); err != nil {
 			return helpers.InvalidTokenError(e)
@@ -255,7 +262,7 @@ func (s *Server) handleOauthSessionMiddleware(next echo.HandlerFunc) echo.Handle
 		}
 
 		if pts[0] != "DPoP" {
-			return next(e)
+			return s.authorizeEndpoint(e, next)
 		}
 
 		accessToken := pts[1]
@@ -323,7 +330,8 @@ func (s *Server) handleOauthSessionMiddleware(next echo.HandlerFunc) echo.Handle
 		e.Set("did", repo.Repo.Did)
 		e.Set("token", accessToken)
 		e.Set("scopes", strings.Split(oauthToken.Parameters.Scope, " "))
+		e.Set("credentialKind", credentialOAuth)
 
-		return next(e)
+		return s.authorizeEndpoint(e, next)
 	}
 }

--- a/server/scope_enforcement.go
+++ b/server/scope_enforcement.go
@@ -10,13 +10,14 @@ import (
 // hasRPCScope checks the exact method and audience before delegating authority.
 // An omitted method requests an unrestricted token and requires lxm=*.
 func (s *Server) hasRPCScope(e echo.Context, aud, lxm string) bool {
-	raw := e.Get("scopes")
-	if raw == nil {
-		// Only authenticated legacy bearer requests may omit OAuth scope state.
-		scheme, _, _ := strings.Cut(e.Request().Header.Get("Authorization"), " ")
-		return strings.EqualFold(scheme, "Bearer")
+	kind := e.Get("credentialKind")
+	if kind == credentialLegacyAccess || kind == credentialService {
+		return true
 	}
-	granted, ok := raw.([]string)
+	if kind != credentialOAuth {
+		return false
+	}
+	granted, ok := e.Get("scopes").([]string)
 	if !ok {
 		return false
 	}
@@ -59,21 +60,18 @@ func actionForOpType(t OpType) string {
 	}
 }
 
-// hasRepoScope reports whether the current session is permitted to perform a
-// repo write of action on collection.
-//
-// Sessions without OAuth scopes (password/legacy access tokens, which never set
-// "scopes") are unrestricted, as is the legacy broad-write transition:generic
-// scope. Otherwise the granted scopes must include a repo: scope covering the
-// collection and action.
+// hasRepoScope checks write permission for a collection and action.
 func (s *Server) hasRepoScope(e echo.Context, collection, action string) bool {
-	raw := e.Get("scopes")
-	if raw == nil {
+	kind := e.Get("credentialKind")
+	if kind == credentialLegacyAccess || kind == credentialService {
 		return true
 	}
-	granted, ok := raw.([]string)
+	if kind != credentialOAuth {
+		return false
+	}
+	granted, ok := e.Get("scopes").([]string)
 	if !ok {
-		return true
+		return false
 	}
 
 	for _, tok := range granted {

--- a/server/scope_enforcement_test.go
+++ b/server/scope_enforcement_test.go
@@ -14,6 +14,9 @@ func ctxWithScopes(scopes any) echo.Context {
 	c, _ := newRequestContext(http.MethodPost, "/", "", nil)
 	if scopes != nil {
 		c.Set("scopes", scopes)
+		c.Set("credentialKind", credentialOAuth)
+	} else {
+		c.Set("credentialKind", credentialLegacyAccess)
 	}
 	return c
 }
@@ -38,6 +41,9 @@ func TestHasRPCScopeStateAndAudience(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c := ctxWithScopes(tc.scopes)
 			c.Request().Header.Set("Authorization", tc.scheme+" token")
+			if tc.scheme == "DPoP" {
+				c.Set("credentialKind", credentialOAuth)
+			}
 			if got := s.hasRPCScope(c, tc.aud, method); got != tc.want {
 				t.Fatalf("hasRPCScope = %v, want %v", got, tc.want)
 			}
@@ -106,6 +112,7 @@ func TestCreateRecordInsufficientScope(t *testing.T) {
 	body := `{"repo":"` + ra.Repo.Did + `","collection":"earth.cirrus.check.othertestrecord","record":{"foo":"bar"}}`
 	c, rec := newRequestContext(http.MethodPost, "/xrpc/com.atproto.repo.createRecord", body, nil)
 	c.Set("repo", ra)
+	c.Set("credentialKind", credentialOAuth)
 	c.Set("scopes", []string{"atproto", "repo:earth.cirrus.check.testrecord"})
 
 	if err := s.handleCreateRecord(c); err != nil {
@@ -121,6 +128,7 @@ func TestPutRecordInsufficientScope(t *testing.T) {
 	body := `{"repo":"` + ra.Repo.Did + `","collection":"earth.cirrus.check.othertestrecord","rkey":"self","record":{"foo":"bar"}}`
 	c, rec := newRequestContext(http.MethodPost, "/xrpc/com.atproto.repo.putRecord", body, nil)
 	c.Set("repo", ra)
+	c.Set("credentialKind", credentialOAuth)
 	c.Set("scopes", []string{"atproto", "repo:earth.cirrus.check.testrecord"})
 
 	if err := s.handlePutRecord(c); err != nil {
@@ -136,6 +144,7 @@ func TestDeleteRecordInsufficientScope(t *testing.T) {
 	body := `{"repo":"` + ra.Repo.Did + `","collection":"earth.cirrus.check.othertestrecord","rkey":"self"}`
 	c, rec := newRequestContext(http.MethodPost, "/xrpc/com.atproto.repo.deleteRecord", body, nil)
 	c.Set("repo", ra)
+	c.Set("credentialKind", credentialOAuth)
 	c.Set("scopes", []string{"atproto", "repo:earth.cirrus.check.testrecord"})
 
 	if err := s.handleDeleteRecord(c); err != nil {
@@ -151,6 +160,7 @@ func TestApplyWritesInsufficientScope(t *testing.T) {
 	body := `{"repo":"` + ra.Repo.Did + `","writes":[{"$type":"com.atproto.repo.applyWrites#create","collection":"earth.cirrus.check.othertestrecord","rkey":"self","value":{"foo":"bar"}}]}`
 	c, rec := newRequestContext(http.MethodPost, "/xrpc/com.atproto.repo.applyWrites", body, nil)
 	c.Set("repo", ra)
+	c.Set("credentialKind", credentialOAuth)
 	c.Set("scopes", []string{"atproto", "repo:earth.cirrus.check.testrecord"})
 
 	if err := s.handleApplyWrites(c); err != nil {


### PR DESCRIPTION
A follow-up to the earlier OAuth authorization fixes. This covers the remaining endpoint permission checks for account and identity operations, repo imports, blob uploads, and preferences. It also keeps email details out of `getSession` responses unless the caller has permission to read them.

Checks run before handlers read request bodies or change state. Tests cover denied requests, allowed operations, and legacy-session compatibility.

Recovery and migration integrity fixes are left for separate PRs to keep this focused.