### PR TITLE
Delete superseded blocks on commit + gc-repos migration, matching reference PDS

### DIFF
--- a/cmd/cocoon/main.go
+++ b/cmd/cocoon/main.go
@@ -173,6 +173,7 @@ func main() {
 			runCreateInviteCode,
 			runResetPassword,
 			runRecommitRepos,
+			runGcRepos,
 		},
 		ErrWriter: os.Stdout,
 		Version:   Version,
@@ -483,6 +484,89 @@ var runRecommitRepos = &cli.Command{
 		}
 		if failures > 0 {
 			return fmt.Errorf("%d repo(s) failed", failures)
+		}
+		return nil
+	},
+}
+
+var runGcRepos = &cli.Command{
+	Name:  "gc-repos",
+	Usage: "Delete blocks unreachable from repos' current head commits",
+	Description: "For each listed repo, walks the MST at the current head and deletes every block " +
+		"not reachable from it: superseded MST nodes, blocks of deleted or overwritten records, " +
+		"and historical commit objects — the strata accumulated before commits started deleting " +
+		"their removedCids. This shrinks the database and future getRepo exports.\n\n" +
+		"Dry-run by default; pass --confirm to apply. Run with the PDS STOPPED (a concurrent write " +
+		"would race this pass). For SQLite, run VACUUM afterwards to return the freed space to the OS. " +
+		"The repos themselves are never mutated: no new commits, no firehose events.",
+	Flags: []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:     "dids",
+			Usage:    "repos to process (repeat the flag or comma-separate)",
+			Required: true,
+		},
+		&cli.BoolFlag{
+			Name:  "confirm",
+			Usage: "actually delete garbage blocks (otherwise dry-run)",
+		},
+	},
+	Action: func(cmd *cli.Context) error {
+		dids := cmd.StringSlice("dids")
+		if len(dids) == 0 {
+			return fmt.Errorf("at least one --dids value is required")
+		}
+		for _, d := range dids {
+			if _, err := syntax.ParseDID(d); err != nil {
+				return fmt.Errorf("invalid did %q: %w", d, err)
+			}
+		}
+
+		gdb, err := newDb(cmd)
+		if err != nil {
+			return err
+		}
+
+		dryRun := !cmd.Bool("confirm")
+		if dryRun {
+			fmt.Println("DRY RUN — no changes will be made. Re-run with --confirm to apply.")
+		} else {
+			fmt.Println("APPLYING changes. Ensure the PDS is STOPPED so no write races this pass.")
+		}
+
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		results, err := server.RunRepoGcMigration(context.Background(), gdb, server.RepoGcOptions{
+			Dids:              dids,
+			DryRun:            dryRun,
+			BlockstoreVariant: cmd.String("blockstore-variant"),
+			Logger:            logger,
+		})
+		if err != nil {
+			return err
+		}
+
+		var failures int
+		for _, r := range results {
+			if r.Err != nil {
+				failures++
+				fmt.Printf("  %s: ERROR: %v\n", r.Did, r.Err)
+				continue
+			}
+			switch {
+			case dryRun && r.RemovedBlocks > 0:
+				fmt.Printf("  %s: would delete %d of %d blocks (head %s, %d live)\n", r.Did, r.RemovedBlocks, r.TotalBlocks, r.Head, r.LiveBlocks)
+			case dryRun:
+				fmt.Printf("  %s: already clean (head %s, %d live)\n", r.Did, r.Head, r.LiveBlocks)
+			case r.RemovedBlocks > 0:
+				fmt.Printf("  %s: deleted %d of %d blocks (head %s, %d live)\n", r.Did, r.RemovedBlocks, r.TotalBlocks, r.Head, r.LiveBlocks)
+			default:
+				fmt.Printf("  %s: already clean (head %s, %d live)\n", r.Did, r.Head, r.LiveBlocks)
+			}
+		}
+		if failures > 0 {
+			return fmt.Errorf("%d repo(s) failed", failures)
+		}
+		if !dryRun {
+			fmt.Println("Done. For SQLite, run VACUUM to return freed space to the OS.")
 		}
 		return nil
 	},

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/ipfs/go-cid v0.6.0
 	github.com/ipfs/go-ipfs-blockstore v1.3.1
 	github.com/ipfs/go-ipld-cbor v0.2.1
+	github.com/ipfs/go-ipld-format v0.6.3
 	github.com/ipld/go-car v0.6.3
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo-contrib v0.50.1
@@ -71,7 +72,6 @@ require (
 	github.com/ipfs/go-dsqueue v0.2.0 // indirect
 	github.com/ipfs/go-ipfs-ds-help v1.1.1 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.3 // indirect
-	github.com/ipfs/go-ipld-format v0.6.3 // indirect
 	github.com/ipfs/go-ipld-legacy v0.3.0 // indirect
 	github.com/ipfs/go-libipfs v0.7.0 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect

--- a/recording_blockstore/recording_blockstore.go
+++ b/recording_blockstore/recording_blockstore.go
@@ -14,6 +14,9 @@ type RecordingBlockstore struct {
 
 	inserts map[cid.Cid]blockformat.Block
 	reads   map[cid.Cid]blockformat.Block
+	// deletions recorded by CID, so they can be filtered out of any derived
+	// views of this session's writes
+	deleted map[cid.Cid]struct{}
 }
 
 func New(base blockstore.Blockstore) *RecordingBlockstore {
@@ -21,6 +24,7 @@ func New(base blockstore.Blockstore) *RecordingBlockstore {
 		base:    base,
 		inserts: make(map[cid.Cid]blockformat.Block),
 		reads:   make(map[cid.Cid]blockformat.Block),
+		deleted: make(map[cid.Cid]struct{}),
 	}
 }
 
@@ -42,7 +46,23 @@ func (bs *RecordingBlockstore) GetSize(ctx context.Context, c cid.Cid) (int, err
 }
 
 func (bs *RecordingBlockstore) DeleteBlock(ctx context.Context, c cid.Cid) error {
-	return bs.base.DeleteBlock(ctx, c)
+	if err := bs.base.DeleteBlock(ctx, c); err != nil {
+		return err
+	}
+	bs.deleted[c] = struct{}{}
+	delete(bs.inserts, c)
+	return nil
+}
+
+// DeleteMany removes several blocks at once from the base store, recording
+// the deletions so they are excluded from GetWriteLog.
+func (bs *RecordingBlockstore) DeleteMany(ctx context.Context, cids []cid.Cid) error {
+	for _, c := range cids {
+		if err := bs.DeleteBlock(ctx, c); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (bs *RecordingBlockstore) Put(ctx context.Context, block blockformat.Block) error {

--- a/server/firehose_sync_test.go
+++ b/server/firehose_sync_test.go
@@ -100,6 +100,14 @@ func TestApplyWritesEmitsPrevData(t *testing.T) {
 	}
 	defer cancel()
 
+	// capture the expected prevData before the write: the previous commit's
+	// MST root. (The previous commit block itself is deleted once superseded,
+	// matching the reference PDS, so it cannot be read back afterwards.)
+	wantPrev, err := readCommitData(ctx, s.getBlockstore(acct.Did), root)
+	if err != nil {
+		t.Fatalf("readCommitData: %v", err)
+	}
+
 	rec := MarshalableMap{
 		"$type":     "app.bsky.feed.post",
 		"text":      "hello world",
@@ -111,11 +119,6 @@ func TestApplyWritesEmitsPrevData(t *testing.T) {
 		Record:     &rec,
 	}}, nil); err != nil {
 		t.Fatalf("applyWrites: %v", err)
-	}
-
-	wantPrev, err := readCommitData(ctx, s.getBlockstore(acct.Did), root)
-	if err != nil {
-		t.Fatalf("readCommitData: %v", err)
 	}
 
 	select {

--- a/server/repo.go
+++ b/server/repo.go
@@ -250,6 +250,91 @@ func putRecordBlock(ctx context.Context, bs blockstore.Blockstore, rec *Marshala
 	return c, nil
 }
 
+// collectTreeBlocks gathers the CIDs of all MST node blocks reachable from a
+// tree root, plus the CIDs of all leaf (record) values.
+func collectTreeBlocks(n *mst.Node, nodes map[cid.Cid]struct{}, leaves map[cid.Cid]struct{}) {
+	if n == nil {
+		return
+	}
+	if n.CID != nil {
+		nodes[*n.CID] = struct{}{}
+	}
+	for _, e := range n.Entries {
+		if e.Child != nil {
+			collectTreeBlocks(e.Child, nodes, leaves)
+		}
+		if e.IsValue() && e.Value != nil {
+			leaves[*e.Value] = struct{}{}
+		}
+	}
+}
+
+// computeRemovedCids returns the set of block CIDs that should be deleted
+// from storage after a commit that moved the MST from prev to curr:
+//
+//   - MST node blocks reachable from prev but not from curr
+//   - record blocks linked from prev but not from curr (updates/deletes)
+//   - the previous commit block(s)
+//   - blocks written by this commit (newBlocks) that ended up unlinked, eg a
+//     record created and then deleted within the same batch
+//
+// newRoot (the new commit block) is always kept.
+//
+// This mirrors the reference PDS DataDiff removedCids computation, including
+// its add/remove cancel-out for same-batch churn.
+func computeRemovedCids(prev *mst.Node, curr *mst.Node, prevCommitCids []cid.Cid, newBlocks []cid.Cid, newRoot cid.Cid) []cid.Cid {
+	prevNodes := map[cid.Cid]struct{}{}
+	prevLeaves := map[cid.Cid]struct{}{}
+	collectTreeBlocks(prev, prevNodes, prevLeaves)
+
+	currNodes := map[cid.Cid]struct{}{}
+	currLeaves := map[cid.Cid]struct{}{}
+	collectTreeBlocks(curr, currNodes, currLeaves)
+
+	linked := func(c cid.Cid) bool {
+		if c == newRoot {
+			return true
+		}
+		if _, ok := currNodes[c]; ok {
+			return true
+		}
+		if _, ok := currLeaves[c]; ok {
+			return true
+		}
+		return false
+	}
+
+	removed := map[cid.Cid]struct{}{}
+	for c := range prevNodes {
+		if !linked(c) {
+			removed[c] = struct{}{}
+		}
+	}
+	for c := range prevLeaves {
+		if !linked(c) {
+			removed[c] = struct{}{}
+		}
+	}
+	for _, c := range prevCommitCids {
+		if !linked(c) {
+			removed[c] = struct{}{}
+		}
+	}
+	// blocks written this commit that are not linked from the new root are
+	// garbage (eg create+delete of the same rkey in one batch)
+	for _, c := range newBlocks {
+		if !linked(c) {
+			removed[c] = struct{}{}
+		}
+	}
+
+	out := make([]cid.Cid, 0, len(removed))
+	for c := range removed {
+		out = append(out, c)
+	}
+	return out
+}
+
 // TODO make use of swap commit
 func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []Op, swapCommit *string) ([]ApplyWriteResult, error) {
 	rootcid, err := cid.Cast(urepo.Root)
@@ -274,8 +359,13 @@ func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []
 	var entries []models.Record
 	var newroot cid.Cid
 	var rev string
+	var removedCids []cid.Cid
 
 	if err := rm.withRepo(ctx, urepo.Did, rootcid, func(r *atp.Repo) (cid.Cid, error) {
+		// Snapshot the pre-write tree so we can compute which blocks this
+		// commit supersedes (removedCids) after mutating.
+		prevTree := r.MST.Copy()
+
 		entries = make([]models.Record, 0, len(writes))
 		for i, op := range writes {
 			// updates or deletes must supply an rkey
@@ -430,6 +520,16 @@ func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []
 			return cid.Undef, commitErr
 		}
 
+		// Compute the blocks superseded by this commit, mirroring the
+		// reference PDS: every MST node CID that was reachable before and is
+		// not reachable now, every record CID that is no longer linked, the
+		// previous commit block, and same-batch garbage (eg create+delete).
+		var newBlocks []cid.Cid
+		for _, blk := range bs.GetWriteLog() {
+			newBlocks = append(newBlocks, blk.Cid())
+		}
+		removedCids = computeRemovedCids(prevTree.Root, r.MST.Root, []cid.Cid{rootcid}, newBlocks, newroot)
+
 		return newroot, nil
 	}); err != nil {
 		return nil, err
@@ -560,6 +660,26 @@ func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []
 
 	if err := rm.s.UpdateRepo(ctx, urepo.Did, newroot, rev); err != nil {
 		return nil, err
+	}
+
+	// Delete the blocks superseded by this commit, matching the reference PDS
+	// (which deletes commit.removedCids alongside applying the new blocks).
+	// This runs after the firehose event is built and published: the event CAR
+	// embeds the removed record blocks so consumers can apply the ops.
+	//
+	// TODO: this delete is not atomic with the block insert above; a crash
+	// between the two leaves a superseded block stranded in storage (bloat,
+	// not corruption).
+	if len(removedCids) > 0 {
+		dm, ok := dbs.(interface {
+			DeleteMany(context.Context, []cid.Cid) error
+		})
+		if !ok {
+			return nil, fmt.Errorf("blockstore does not support deleting superseded blocks")
+		}
+		if err := dm.DeleteMany(ctx, removedCids); err != nil {
+			return nil, fmt.Errorf("deleting superseded blocks: %w", err)
+		}
 	}
 
 	for i := range results {

--- a/server/repo_gc.go
+++ b/server/repo_gc.go
@@ -100,56 +100,47 @@ func (s *Server) repoGcOne(ctx context.Context, did string, dryRun bool) RepoGcR
 
 	res.LiveBlocks = int64(len(live))
 
-	// Count current rows and find the unreachable ones in one query.
-	var total int64
-	if err := s.db.Client().Table("blocks").Where("did = ?", did).Count(&total).Error; err != nil {
-		res.Err = fmt.Errorf("count blocks: %w", err)
+	// Load and validate every block row BEFORE any accounting or the dry-run
+	// return, so dry-run and --confirm observe identical corruption behavior
+	// and the removal count comes from actual rows, not a subtraction that
+	// assumes every live CID has a row.
+	var rows []models.Block
+	if err := s.db.Client().Table("blocks").Where("did = ?", did).Find(&rows).Error; err != nil {
+		res.Err = fmt.Errorf("load blocks: %w", err)
 		return res
 	}
-	res.TotalBlocks = total
-	res.RemovedBlocks = total - res.LiveBlocks
+	var dead []cid.Cid
+	for _, row := range rows {
+		c, err := cid.Cast(row.Cid)
+		if err != nil {
+			// A row whose cid column cannot even be parsed signals real
+			// corruption; fail this repo's pass rather than guessing at a
+			// deletion key (cid.Undef would not match the stored bytes).
+			res.Err = fmt.Errorf("unparseable block cid row for did %s: %w", did, err)
+			return res
+		}
+		if _, ok := live[c]; !ok {
+			dead = append(dead, c)
+		}
+	}
+	res.TotalBlocks = int64(len(rows))
+	res.RemovedBlocks = int64(len(dead))
 
 	if dryRun {
 		return res
 	}
 
-	if res.RemovedBlocks > 0 {
-		// Delete in batches over the live set rather than building a giant
-		// NOT IN clause: fetch candidate cids, filter against live, delete.
-		var rows []models.Block
-		if err := s.db.Client().Table("blocks").Where("did = ?", did).Find(&rows).Error; err != nil {
-			res.Err = fmt.Errorf("load blocks: %w", err)
+	if len(dead) > 0 {
+		dm, ok := s.getBlockstore(did).(interface {
+			DeleteMany(context.Context, []cid.Cid) error
+		})
+		if !ok {
+			res.Err = fmt.Errorf("blockstore does not support deleting blocks")
 			return res
 		}
-		var dead []cid.Cid
-		for _, row := range rows {
-			c, err := cid.Cast(row.Cid)
-			if err != nil {
-				// A row whose cid column cannot even be parsed signals real
-				// corruption; fail this repo's pass rather than guessing at a
-				// deletion key (cid.Undef would not match the stored bytes).
-				res.Err = fmt.Errorf("unparseable block cid row for did %s: %w", did, err)
-				return res
-			}
-			if _, ok := live[c]; !ok {
-				dead = append(dead, c)
-			}
-		}
-		if len(dead) > 0 {
-			dm, ok := s.getBlockstore(did).(interface {
-				DeleteMany(context.Context, []cid.Cid) error
-			})
-			if !ok {
-				res.Err = fmt.Errorf("blockstore does not support deleting blocks")
-				return res
-			}
-			if err := dm.DeleteMany(ctx, dead); err != nil {
-				res.Err = fmt.Errorf("delete garbage blocks: %w", err)
-				return res
-			}
-			res.RemovedBlocks = int64(len(dead))
-		} else {
-			res.RemovedBlocks = 0
+		if err := dm.DeleteMany(ctx, dead); err != nil {
+			res.Err = fmt.Errorf("delete garbage blocks: %w", err)
+			return res
 		}
 	}
 

--- a/server/repo_gc.go
+++ b/server/repo_gc.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/haileyok/cocoon/internal/db"
+	"github.com/haileyok/cocoon/models"
+	"github.com/ipfs/go-cid"
+	"gorm.io/gorm"
+)
+
+// RepoGcOptions configures RunRepoGcMigration.
+type RepoGcOptions struct {
+	// Dids is the set of repos to process.
+	Dids []string
+	// DryRun reports planned deletions without removing any blocks.
+	DryRun bool
+	// BlockstoreVariant selects the block store (mirrors the server flag).
+	BlockstoreVariant string
+	Logger            *slog.Logger
+}
+
+// RepoGcResult is the per-repo outcome of the migration.
+type RepoGcResult struct {
+	Did           string
+	Head          string
+	TotalBlocks   int64
+	LiveBlocks    int64
+	RemovedBlocks int64
+	Err           error
+}
+
+// RunRepoGcMigration removes blocks that are unreachable from a repo's
+// current head commit: superseded MST nodes, blocks of deleted or
+// overwritten records, and historical commit objects — the strata
+// accumulated before commits started deleting their removedCids.
+//
+// For each did it walks the MST at the current root, collecting every
+// reachable block CID (the commit block, all MST nodes, all record blocks),
+// then deletes every other block row for that did.
+//
+// The repo itself is never mutated: no new commit, no re-signing, no
+// firehose events. It is still safest to run with the PDS stopped (a
+// concurrent write would race this pass), and a VACUUM may be needed
+// afterwards to return SQLite file space to the OS.
+func RunRepoGcMigration(ctx context.Context, gdb *gorm.DB, opts RepoGcOptions) ([]RepoGcResult, error) {
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	dbw := db.NewDB(gdb)
+
+	var bsv BlockstoreVariant = BlockstoreVariantSqlite
+	if opts.BlockstoreVariant != "" {
+		bsv = MustReturnBlockstoreVariant(opts.BlockstoreVariant)
+	}
+
+	s := &Server{
+		db:     dbw,
+		logger: logger,
+		config: &config{BlockstoreVariant: bsv},
+	}
+	s.repoman = NewRepoMan(s)
+
+	results := make([]RepoGcResult, 0, len(opts.Dids))
+	for _, did := range opts.Dids {
+		results = append(results, s.repoGcOne(ctx, did, opts.DryRun))
+	}
+	return results, nil
+}
+
+func (s *Server) repoGcOne(ctx context.Context, did string, dryRun bool) RepoGcResult {
+	res := RepoGcResult{Did: did}
+
+	urepo, err := s.getRepoActorByDid(ctx, did)
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	head, err := cid.Cast(urepo.Repo.Root)
+	if err != nil {
+		res.Err = fmt.Errorf("stored root is not a valid cid: %w", err)
+		return res
+	}
+	res.Head = head.String()
+
+	// Collect every block CID reachable from the head commit: the commit
+	// block itself, all MST node blocks, and all record blocks.
+	live := map[cid.Cid]struct{}{head: {}}
+	r, err := openRepo(ctx, s.getBlockstore(did), head, did)
+	if err != nil {
+		res.Err = fmt.Errorf("open repo at head: %w", err)
+		return res
+	}
+	collectTreeBlocks(r.MST.Root, live, live) // nodes and leaves into one set
+
+	res.LiveBlocks = int64(len(live))
+
+	// Count current rows and find the unreachable ones in one query.
+	var total int64
+	if err := s.db.Client().Table("blocks").Where("did = ?", did).Count(&total).Error; err != nil {
+		res.Err = fmt.Errorf("count blocks: %w", err)
+		return res
+	}
+	res.TotalBlocks = total
+	res.RemovedBlocks = total - res.LiveBlocks
+
+	if dryRun {
+		return res
+	}
+
+	if res.RemovedBlocks > 0 {
+		// Delete in batches over the live set rather than building a giant
+		// NOT IN clause: fetch candidate cids, filter against live, delete.
+		var rows []models.Block
+		if err := s.db.Client().Table("blocks").Where("did = ?", did).Find(&rows).Error; err != nil {
+			res.Err = fmt.Errorf("load blocks: %w", err)
+			return res
+		}
+		var dead []cid.Cid
+		for _, row := range rows {
+			c, err := cid.Cast(row.Cid)
+			if err != nil {
+				// A row whose cid column cannot even be parsed signals real
+				// corruption; fail this repo's pass rather than guessing at a
+				// deletion key (cid.Undef would not match the stored bytes).
+				res.Err = fmt.Errorf("unparseable block cid row for did %s: %w", did, err)
+				return res
+			}
+			if _, ok := live[c]; !ok {
+				dead = append(dead, c)
+			}
+		}
+		if len(dead) > 0 {
+			dm, ok := s.getBlockstore(did).(interface {
+				DeleteMany(context.Context, []cid.Cid) error
+			})
+			if !ok {
+				res.Err = fmt.Errorf("blockstore does not support deleting blocks")
+				return res
+			}
+			if err := dm.DeleteMany(ctx, dead); err != nil {
+				res.Err = fmt.Errorf("delete garbage blocks: %w", err)
+				return res
+			}
+			res.RemovedBlocks = int64(len(dead))
+		} else {
+			res.RemovedBlocks = 0
+		}
+	}
+
+	return res
+}

--- a/server/repo_gc_test.go
+++ b/server/repo_gc_test.go
@@ -198,14 +198,18 @@ func TestRunRepoGcMigrationCorruptCidRowFails(t *testing.T) {
 		t.Fatalf("insert corrupt block row: %v", err)
 	}
 
-	results, err := RunRepoGcMigration(context.Background(), s.db.Client(), RepoGcOptions{
-		Dids: []string{did},
-	})
-	if err != nil {
-		t.Fatalf("RunRepoGcMigration: %v", err)
-	}
-	if len(results) != 1 || results[0].Err == nil {
-		t.Fatalf("expected an error result for the corrupt cid row, got %+v", results)
+	// dry-run and apply must behave identically: both fail on the corrupt row
+	for _, dryRun := range []bool{true, false} {
+		results, err := RunRepoGcMigration(context.Background(), s.db.Client(), RepoGcOptions{
+			Dids:   []string{did},
+			DryRun: dryRun,
+		})
+		if err != nil {
+			t.Fatalf("RunRepoGcMigration(dryRun=%v): %v", dryRun, err)
+		}
+		if len(results) != 1 || results[0].Err == nil {
+			t.Fatalf("dryRun=%v: expected an error result for the corrupt cid row, got %+v", dryRun, results)
+		}
 	}
 
 	// nothing may have been deleted: the pass aborts before any deletion
@@ -215,5 +219,60 @@ func TestRunRepoGcMigrationCorruptCidRowFails(t *testing.T) {
 	}
 	if n < 1 {
 		t.Fatalf("expected blocks to remain, got %d", n)
+	}
+}
+
+// TestRunRepoGcMigrationMissingLiveRowNoNegativeAccounting asserts that when
+// a referenced (live) record block has no row in the blocks table, the GC
+// does not report a negative removal count — dead blocks are counted from
+// actual rows, never by subtraction.
+func TestRunRepoGcMigrationMissingLiveRowNoNegativeAccounting(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	did := gcCreateChurnedRepo(t, s)
+	garbage := gcInsertGarbageBlocks(t, s, did, 2)
+
+	// remove one live record block's row entirely (simulating a missing row)
+	leaves := walkMstLeaves(t, s, did)
+	var victim cid.Cid
+	found := false
+	for _, c := range leaves {
+		victim = c
+		found = true
+		break
+	}
+	if !found {
+		t.Fatal("no live leaves to remove")
+	}
+	if err := s.db.Client().Exec("DELETE FROM blocks WHERE did = ? AND cid = ?", did, victim.Bytes()).Error; err != nil {
+		t.Fatalf("delete live row: %v", err)
+	}
+
+	for _, dryRun := range []bool{true, false} {
+		results, err := RunRepoGcMigration(context.Background(), s.db.Client(), RepoGcOptions{
+			Dids:   []string{did},
+			DryRun: dryRun,
+		})
+		if err != nil {
+			t.Fatalf("RunRepoGcMigration(dryRun=%v): %v", dryRun, err)
+		}
+		if len(results) != 1 || results[0].Err != nil {
+			t.Fatalf("dryRun=%v: unexpected results: %+v", dryRun, results)
+		}
+		r := results[0]
+		if r.RemovedBlocks < 0 || r.RemovedBlocks > r.TotalBlocks {
+			t.Fatalf("dryRun=%v: nonsensical removal count: removed=%d total=%d", dryRun, r.RemovedBlocks, r.TotalBlocks)
+		}
+		if r.RemovedBlocks != int64(len(garbage)) {
+			t.Fatalf("dryRun=%v: expected %d removals, got %d", dryRun, len(garbage), r.RemovedBlocks)
+		}
+	}
+
+	// garbage is gone; the still-live rows that remain are intact
+	for _, g := range garbage {
+		if blockExists(t, s, did, g) {
+			t.Fatalf("garbage block %s still present after gc", g)
+		}
 	}
 }

--- a/server/repo_gc_test.go
+++ b/server/repo_gc_test.go
@@ -1,0 +1,219 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+)
+
+// gcCreateChurnedRepo seeds a repo with several records and churns it
+// (update + delete). Since every applyWrites now deletes superseded blocks,
+// dangling garbage is simulated by inserting unreachable rows directly into
+// the blocks table (the state a pre-fix database is actually in).
+func gcCreateChurnedRepo(t *testing.T, s *Server) string {
+	t.Helper()
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+	did := acct.Did
+
+	ops := make([]Op, 0, 4)
+	for _, rk := range []string{"aaaa", "cccc", "eeee", "gggg"} {
+		ops = append(ops, Op{
+			Type:       OpTypeCreate,
+			Collection: "app.bsky.feed.post",
+			Rkey:       &rk,
+			Record:     rmPostRecord("post " + rk),
+		})
+	}
+	mustApply(t, s, did, ops...)
+
+	mustApply(t, s, did,
+		Op{Type: OpTypeUpdate, Collection: "app.bsky.feed.post", Rkey: strPtr("cccc"), Record: rmPostRecord("updated")},
+		Op{Type: OpTypeDelete, Collection: "app.bsky.feed.post", Rkey: strPtr("gggg")},
+	)
+
+	return did
+}
+
+// gcInsertGarbageBlocks inserts n unreachable block rows for a did, mimicking
+// the strata a pre-fix database accumulated (superseded MST nodes, deleted
+// records, historical commits). Values are dag-cbor-shaped so the rows look
+// like real data.
+func gcInsertGarbageBlocks(t *testing.T, s *Server, did string, n int) []cid.Cid {
+	t.Helper()
+	out := make([]cid.Cid, 0, n)
+	for i := 0; i < n; i++ {
+		payload := []byte{0xA5, 0x01, byte(i), 0x02, byte(i + 1)}
+		c := mkTestCid(t, payload)
+		if err := s.db.Client().Exec(
+			"INSERT INTO blocks (did, cid, rev, value) VALUES (?, ?, ?, ?)",
+			did, c.Bytes(), "3lmbbsbe4m2a", payload,
+		).Error; err != nil {
+			t.Fatalf("insert garbage block: %v", err)
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func mkTestCid(t *testing.T, b []byte) cid.Cid {
+	t.Helper()
+	pref := cid.NewPrefixV1(cid.DagCBOR, multihash.SHA2_256)
+	c, err := pref.Sum(b)
+	if err != nil {
+		t.Fatalf("sum cid: %v", err)
+	}
+	return c
+}
+
+func TestRunRepoGcMigrationDryRun(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	did := gcCreateChurnedRepo(t, s)
+	garbage := gcInsertGarbageBlocks(t, s, did, 3)
+
+	before := countBlocks(t, s, did)
+
+	results, err := RunRepoGcMigration(context.Background(), s.db.Client(), RepoGcOptions{
+		Dids:   []string{did},
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("RunRepoGcMigration: %v", err)
+	}
+	if len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+	if results[0].RemovedBlocks != 3 {
+		t.Fatalf("dry-run should report 3 garbage blocks, got %d", results[0].RemovedBlocks)
+	}
+	if got := countBlocks(t, s, did); got != before {
+		t.Fatalf("dry-run mutated blocks: before=%d after=%d", before, got)
+	}
+	for _, g := range garbage {
+		if !blockExists(t, s, did, g) {
+			t.Fatalf("dry-run deleted garbage block %s", g)
+		}
+	}
+}
+
+func TestRunRepoGcMigration(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	did := gcCreateChurnedRepo(t, s)
+	garbage := gcInsertGarbageBlocks(t, s, did, 3)
+
+	leaves := walkMstLeaves(t, s, did)
+	if len(leaves) != 3 {
+		t.Fatalf("expected 3 live records after churn, got %d", len(leaves))
+	}
+
+	results, err := RunRepoGcMigration(context.Background(), s.db.Client(), RepoGcOptions{
+		Dids: []string{did},
+	})
+	if err != nil {
+		t.Fatalf("RunRepoGcMigration: %v", err)
+	}
+	if len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+	if results[0].RemovedBlocks != 3 {
+		t.Fatalf("expected 3 garbage blocks removed, got %d", results[0].RemovedBlocks)
+	}
+
+	// garbage must be gone
+	for _, g := range garbage {
+		if blockExists(t, s, did, g) {
+			t.Fatalf("garbage block %s still present after gc", g)
+		}
+	}
+
+	// every live record block must survive
+	for path, c := range leaves {
+		if !blockExists(t, s, did, c) {
+			t.Fatalf("live record block %s for %s removed by gc", c, path)
+		}
+	}
+
+	// the repo must still open and its leaves must still be reachable
+	root := currentRoot(t, s, did)
+	if _, err := openRepo(context.Background(), s.getBlockstore(did), root, did); err != nil {
+		t.Fatalf("repo no longer opens after gc: %v", err)
+	}
+	if got := len(walkMstLeaves(t, s, did)); got != 3 {
+		t.Fatalf("leaf count changed after gc: %d", got)
+	}
+}
+
+func TestRunRepoGcMigrationNoGarbage(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	did := gcCreateChurnedRepo(t, s)
+
+	results, err := RunRepoGcMigration(context.Background(), s.db.Client(), RepoGcOptions{
+		Dids: []string{did},
+	})
+	if err != nil {
+		t.Fatalf("RunRepoGcMigration: %v", err)
+	}
+	if len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+	if results[0].RemovedBlocks != 0 {
+		t.Fatalf("expected 0 removals for a clean repo, got %d", results[0].RemovedBlocks)
+	}
+}
+
+func TestRunRepoGcMigrationUnknownDid(t *testing.T) {
+	s := newTestServer(t)
+
+	results, err := RunRepoGcMigration(context.Background(), s.db.Client(), RepoGcOptions{
+		Dids: []string{"did:plc:nonexistent0000000000000000"},
+	})
+	if err != nil {
+		t.Fatalf("RunRepoGcMigration: %v", err)
+	}
+	if len(results) != 1 || results[0].Err == nil {
+		t.Fatalf("expected an error result for an unknown did, got %+v", results)
+	}
+}
+
+func TestRunRepoGcMigrationCorruptCidRowFails(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	did := gcCreateChurnedRepo(t, s)
+
+	// insert a row with a cid that cannot be parsed: the migration must fail
+	// the repo's pass instead of guessing a deletion key
+	if err := s.db.Client().Exec(
+		"INSERT INTO blocks (did, cid, rev, value) VALUES (?, ?, ?, ?)",
+		did, []byte{0x00, 0x01, 0x02}, "3lmbbsbe4m2a", []byte{0xA5, 0x01},
+	).Error; err != nil {
+		t.Fatalf("insert corrupt block row: %v", err)
+	}
+
+	results, err := RunRepoGcMigration(context.Background(), s.db.Client(), RepoGcOptions{
+		Dids: []string{did},
+	})
+	if err != nil {
+		t.Fatalf("RunRepoGcMigration: %v", err)
+	}
+	if len(results) != 1 || results[0].Err == nil {
+		t.Fatalf("expected an error result for the corrupt cid row, got %+v", results)
+	}
+
+	// nothing may have been deleted: the pass aborts before any deletion
+	var n int64
+	if err := s.db.Client().Table("blocks").Where("did = ?", did).Count(&n).Error; err != nil {
+		t.Fatalf("count blocks: %v", err)
+	}
+	if n < 1 {
+		t.Fatalf("expected blocks to remain, got %d", n)
+	}
+}

--- a/server/repo_removed_cids_test.go
+++ b/server/repo_removed_cids_test.go
@@ -1,0 +1,718 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/atproto/atcrypto"
+	atp "github.com/bluesky-social/indigo/atproto/repo"
+	"github.com/bluesky-social/indigo/atproto/repo/mst"
+	"github.com/bluesky-social/indigo/events"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-car"
+	"github.com/multiformats/go-multihash"
+)
+
+// walkMstLeaves opens the repo at its current head and collects every leaf
+// key -> CID pair in the MST.
+func walkMstLeaves(t *testing.T, s *Server, did string) map[string]cid.Cid {
+	t.Helper()
+	urepo, err := s.getRepoActorByDid(context.Background(), did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+	root, err := cid.Cast(urepo.Root)
+	if err != nil {
+		t.Fatalf("cast root: %v", err)
+	}
+	r, err := openRepo(context.Background(), s.getBlockstore(did), root, did)
+	if err != nil {
+		t.Fatalf("openRepo: %v", err)
+	}
+	leaves := map[string]cid.Cid{}
+	if err := r.MST.Walk(func(key []byte, val cid.Cid) error {
+		leaves[string(key)] = val
+		return nil
+	}); err != nil {
+		t.Fatalf("walk mst: %v", err)
+	}
+	return leaves
+}
+
+// currentRoot returns the repo's current head commit CID.
+func currentRoot(t *testing.T, s *Server, did string) cid.Cid {
+	t.Helper()
+	urepo, err := s.getRepoActorByDid(context.Background(), did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+	root, err := cid.Cast(urepo.Root)
+	if err != nil {
+		t.Fatalf("cast root: %v", err)
+	}
+	return root
+}
+
+// collectTreeStructuralCids walks the MST at root and returns the CIDs of
+// every MST node block in the tree (not record blocks).
+func collectTreeStructuralCids(t *testing.T, s *Server, did string, root cid.Cid) map[cid.Cid]struct{} {
+	t.Helper()
+	r, err := openRepo(context.Background(), s.getBlockstore(did), root, did)
+	if err != nil {
+		t.Fatalf("openRepo: %v", err)
+	}
+	out := map[cid.Cid]struct{}{}
+	var walk func(n *mst.Node)
+	walk = func(n *mst.Node) {
+		if n == nil {
+			return
+		}
+		if n.CID != nil {
+			out[*n.CID] = struct{}{}
+		}
+		for _, e := range n.Entries {
+			if e.Child != nil {
+				walk(e.Child)
+			}
+		}
+	}
+	walk(r.MST.Root)
+	return out
+}
+
+// countBlocks returns the number of block rows for a did.
+func countBlocks(t *testing.T, s *Server, did string) int64 {
+	t.Helper()
+	var n int64
+	if err := s.db.Client().Table("blocks").Where("did = ?", did).Count(&n).Error; err != nil {
+		t.Fatalf("count blocks: %v", err)
+	}
+	return n
+}
+
+// blockExists checks whether a block row exists in the DB for a did+cid.
+func blockExists(t *testing.T, s *Server, did string, c cid.Cid) bool {
+	t.Helper()
+	var n int64
+	if err := s.db.Client().Table("blocks").Where("did = ? AND cid = ?", did, c.Bytes()).Count(&n).Error; err != nil {
+		t.Fatalf("count block rows: %v", err)
+	}
+	return n > 0
+}
+
+// blockstoreHas checks the blockstore API for a cid (fresh instance, so the
+// in-memory inserts map is empty and the DB is consulted directly).
+func blockstoreHas(t *testing.T, s *Server, did string, c cid.Cid) bool {
+	t.Helper()
+	bs := s.getBlockstore(did)
+	_, err := bs.Get(context.Background(), c)
+	return err == nil
+}
+
+func mustApply(t *testing.T, s *Server, did string, ops ...Op) {
+	t.Helper()
+	// fetch the repo fresh each time: applyWrites loads the MST from
+	// urepo.Root, so a stale copy would rewind the tree to an older revision
+	urepo, err := s.getRepoActorByDid(context.Background(), did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+	if _, err := s.repoman.applyWrites(context.Background(), urepo.Repo, ops, nil); err != nil {
+		t.Fatalf("applyWrites: %v", err)
+	}
+}
+
+func rmPostRecord(text string) *MarshalableMap {
+	mm := MarshalableMap{
+		"$type":     "app.bsky.feed.post",
+		"text":      text,
+		"createdAt": "2024-01-01T00:00:00Z",
+	}
+	return &mm
+}
+
+func strPtr(v string) *string { return &v }
+
+// TestApplyWritesRemovesSupersededRecordBlocks asserts that updating a record
+// deletes the prior record version's block, and deleting a record deletes the
+// record block entirely, matching the reference PDS behavior of deleting
+// commit.removedCids.
+func TestApplyWritesRemovesSupersededRecordBlocks(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeCreate,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("r1"),
+		Record:     rmPostRecord("hello"),
+	})
+
+	v1 := walkMstLeaves(t, s, acct.Did)["app.bsky.feed.post/r1"]
+	if v1 == cid.Undef {
+		t.Fatal("record not in MST after create")
+	}
+	blocksAfterCreate := countBlocks(t, s, acct.Did)
+
+	// update with different content
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeUpdate,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("r1"),
+		Record:     rmPostRecord("hello v2"),
+	})
+
+	if blockExists(t, s, acct.Did, v1) {
+		t.Fatal("old record block still present in DB after update")
+	}
+	if blockstoreHas(t, s, acct.Did, v1) {
+		t.Fatal("old record block still gettable via blockstore after update")
+	}
+
+	leaves := walkMstLeaves(t, s, acct.Did)
+	v2 := leaves["app.bsky.feed.post/r1"]
+	if v2 == cid.Undef || v2 == v1 {
+		t.Fatalf("update did not produce a new record CID: v1=%s v2=%s", v1, v2)
+	}
+	if !blockExists(t, s, acct.Did, v2) {
+		t.Fatal("new record block missing after update")
+	}
+
+	// an update writes a new record block and new MST path, and removes the
+	// old record block and old MST path: the table must not grow.
+	blocksAfterUpdate := countBlocks(t, s, acct.Did)
+	if blocksAfterUpdate > blocksAfterCreate {
+		t.Fatalf("block count grew after update: before=%d after=%d", blocksAfterCreate, blocksAfterUpdate)
+	}
+
+	// delete the record
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeDelete,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("r1"),
+	})
+
+	if _, ok := walkMstLeaves(t, s, acct.Did)["app.bsky.feed.post/r1"]; ok {
+		t.Fatal("record still in MST after delete")
+	}
+	if blockExists(t, s, acct.Did, v2) {
+		t.Fatal("deleted record block still present in DB after delete")
+	}
+	if blockstoreHas(t, s, acct.Did, v2) {
+		t.Fatal("deleted record block still gettable via blockstore after delete")
+	}
+}
+
+// TestApplyWritesRemovesSupersededMstNodes asserts that MST nodes superseded
+// by a write are deleted, while MST nodes still linked from the new root are
+// retained.
+func TestApplyWritesRemovesSupersededMstNodes(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	// seed enough records that the MST has multiple levels, so a write to one
+	// key only rewrites the path to that key and other subtrees stay shared
+	rkeys := []string{
+		"aaaa", "cccc", "eeee", "gggg", "iiii",
+		"kkkk", "mmmm", "oooo", "qqqq", "ssss",
+	}
+	ops := make([]Op, 0, len(rkeys))
+	for _, rk := range rkeys {
+		ops = append(ops, Op{
+			Type:       OpTypeCreate,
+			Collection: "app.bsky.feed.post",
+			Rkey:       &rk,
+			Record:     rmPostRecord(fmt.Sprintf("post %s", rk)),
+		})
+	}
+	mustApply(t, s, acct.Did, ops...)
+
+	rootBefore := currentRoot(t, s, acct.Did)
+	structuralBefore := collectTreeStructuralCids(t, s, acct.Did, rootBefore)
+
+	// update one key
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeUpdate,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("kkkk"),
+		Record:     rmPostRecord("updated"),
+	})
+
+	rootAfter := currentRoot(t, s, acct.Did)
+	if rootAfter == rootBefore {
+		t.Fatal("update did not change the root")
+	}
+	structuralAfter := collectTreeStructuralCids(t, s, acct.Did, rootAfter)
+
+	// every node CID linked from both revisions must still be in the store
+	for c := range structuralBefore {
+		if _, linked := structuralAfter[c]; linked {
+			if !blockstoreHas(t, s, acct.Did, c) {
+				t.Fatalf("shared MST node %s deleted but still linked from current root", c)
+			}
+		}
+	}
+
+	// superseded MST nodes (in before, not in after) must be gone
+	removed := 0
+	for c := range structuralBefore {
+		if _, linked := structuralAfter[c]; !linked {
+			removed++
+			if blockstoreHas(t, s, acct.Did, c) {
+				t.Fatalf("superseded MST node %s still present after update", c)
+			}
+		}
+	}
+	if removed == 0 {
+		t.Fatal("expected at least one superseded MST node to be removed")
+	}
+
+	// all leaves must still be reachable
+	if n := len(walkMstLeaves(t, s, acct.Did)); n != len(rkeys) {
+		t.Fatalf("leaf count changed after update: %d", n)
+	}
+}
+
+// TestApplyWritesRemovesSupersededCommitBlocks asserts the previous commit
+// block is deleted when a new commit is written, matching the reference PDS
+// (DataDiff adds the previous commit CID to removedCids).
+func TestApplyWritesRemovesSupersededCommitBlocks(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	genesisRoot, _ := s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	if !blockExists(t, s, acct.Did, genesisRoot) {
+		t.Fatal("genesis commit block missing before write")
+	}
+
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeCreate,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("r1"),
+		Record:     rmPostRecord("hello"),
+	})
+
+	if blockExists(t, s, acct.Did, genesisRoot) {
+		t.Fatal("previous commit block still present after new commit")
+	}
+
+	// the current commit must still be there, and the repo must still open
+	root := currentRoot(t, s, acct.Did)
+	if !blockstoreHas(t, s, acct.Did, root) {
+		t.Fatal("current commit block missing")
+	}
+	if _, err := openRepo(context.Background(), s.getBlockstore(acct.Did), root, acct.Did); err != nil {
+		t.Fatalf("repo no longer opens from current root: %v", err)
+	}
+}
+
+// TestApplyWritesNoopUpdateKeepsRecordBlock asserts that an update writing
+// identical content does not delete the record block.
+func TestApplyWritesNoopUpdateKeepsRecordBlock(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeCreate,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("r1"),
+		Record:     rmPostRecord("hello"),
+	})
+	c1 := walkMstLeaves(t, s, acct.Did)["app.bsky.feed.post/r1"]
+
+	// identical content -> same record CID -> nothing to remove
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeUpdate,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("r1"),
+		Record:     rmPostRecord("hello"),
+	})
+
+	c2 := walkMstLeaves(t, s, acct.Did)["app.bsky.feed.post/r1"]
+	if c1 != c2 {
+		t.Fatalf("identical update produced different record CID: %s vs %s", c1, c2)
+	}
+	if !blockExists(t, s, acct.Did, c1) {
+		t.Fatal("record block removed by no-op update")
+	}
+}
+
+// TestApplyWritesFirehoseAfterRemovals asserts #commit events still carry
+// well-formed CARs (all referenced blocks present) once superseded blocks are
+// being deleted.
+func TestApplyWritesFirehoseAfterRemovals(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	ctx := context.Background()
+
+	evts, cancel, err := s.evtman.Subscribe(ctx, "test", func(*events.XRPCStreamEvent) bool { return true }, nil)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer cancel()
+
+	waitCommit := func() *atproto.SyncSubscribeRepos_Commit {
+		t.Helper()
+		select {
+		case e := <-evts:
+			if e.RepoCommit == nil {
+				t.Fatalf("expected #commit event, got %+v", e)
+			}
+			return e.RepoCommit
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for firehose commit event")
+			return nil
+		}
+	}
+
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeCreate,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("r1"),
+		Record:     rmPostRecord("hello"),
+	})
+	waitCommit()
+
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeUpdate,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("r1"),
+		Record:     rmPostRecord("hello v2"),
+	})
+	evt := waitCommit()
+
+	// parse the event CAR and check every block it advertises can be read back
+	// from the blockstore
+	bs := s.getBlockstore(acct.Did)
+	cr, err := car.NewCarReader(bytes.NewReader(evt.Blocks))
+	if err != nil {
+		t.Fatalf("parse event car: %v", err)
+	}
+	n := 0
+	for {
+		blk, err := cr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read car block: %v", err)
+		}
+		got, err := bs.Get(ctx, blk.Cid())
+		if err != nil {
+			t.Fatalf("event car advertises block %s which is not in the blockstore: %v", blk.Cid(), err)
+		}
+		if !bytes.Equal(got.RawData(), blk.RawData()) {
+			t.Fatalf("block %s bytes differ between event car and blockstore", blk.Cid())
+		}
+		n++
+	}
+	if n == 0 {
+		t.Fatal("event car contained no blocks")
+	}
+
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeDelete,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("r1"),
+	})
+	evt = waitCommit()
+
+	// the delete event CAR embeds the deleted record block's bytes (op.Prev)
+	// so consumers can apply the op without the blockstore; those bytes are
+	// intentionally no longer in the store. Assert the CAR is well-formed and
+	// self-contained, and that every non-record block (commit + MST nodes from
+	// the write log) is still present.
+	cr, err = car.NewCarReader(bytes.NewReader(evt.Blocks))
+	if err != nil {
+		t.Fatalf("parse delete event car: %v", err)
+	}
+	deletedPrev := evt.Ops[0].Prev
+	nDeletedBlocks := 0
+	for {
+		blk, err := cr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read car block: %v", err)
+		}
+		if deletedPrev != nil && blk.Cid().String() == deletedPrev.String() {
+			nDeletedBlocks++
+			continue // embedded prev block: expected absent from store
+		}
+		if _, err := bs.Get(ctx, blk.Cid()); err != nil {
+			t.Fatalf("delete event car advertises block %s which is not in the blockstore: %v", blk.Cid(), err)
+		}
+	}
+	if nDeletedBlocks == 0 {
+		t.Fatal("expected the deleted record block bytes to be embedded in the event CAR")
+	}
+}
+
+// TestApplyWritesBatchCreateThenDeleteCleansBlock asserts that a batch which
+// creates and then deletes the same rkey does not leave the (now unlinked)
+// record block in storage.
+func TestApplyWritesBatchCreateThenDeleteCleansBlock(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	did := acct.Did
+	urepo, err := s.getRepoActorByDid(context.Background(), did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+	blocksBefore := countBlocks(t, s, did)
+
+	rkey := "3laaaaaaaaa2x"
+	rec := rmPostRecord("transient")
+	if _, err := s.repoman.applyWrites(context.Background(), urepo.Repo, []Op{
+		{Type: OpTypeCreate, Collection: "app.bsky.feed.post", Rkey: &rkey, Record: rec},
+		{Type: OpTypeDelete, Collection: "app.bsky.feed.post", Rkey: &rkey},
+	}, nil); err != nil {
+		t.Fatalf("applyWrites create+delete: %v", err)
+	}
+
+	// the tree is empty again, so every block from before except the new
+	// commit must have been removed; nothing may linger
+	blocksAfter := countBlocks(t, s, did)
+	if blocksAfter > blocksBefore {
+		t.Fatalf("create+delete batch left blocks behind: before=%d after=%d", blocksBefore, blocksAfter)
+	}
+
+	leaves := walkMstLeaves(t, s, did)
+	if len(leaves) != 0 {
+		t.Fatalf("expected empty MST after create+delete batch, got %d leaves", len(leaves))
+	}
+}
+
+// TestApplyWritesBatchUpdateThenDeleteCleansBlock asserts that a batch which
+// updates a record and then deletes it removes both the old and the new
+// record blocks.
+func TestApplyWritesBatchUpdateThenDeleteCleansBlock(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	did := acct.Did
+	rkey := "r1"
+	mustApply(t, s, did, Op{
+		Type:       OpTypeCreate,
+		Collection: "app.bsky.feed.post",
+		Rkey:       &rkey,
+		Record:     rmPostRecord("v1"),
+	})
+	v1 := walkMstLeaves(t, s, did)["app.bsky.feed.post/r1"]
+
+	urepo, err := s.getRepoActorByDid(context.Background(), did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+	if _, err := s.repoman.applyWrites(context.Background(), urepo.Repo, []Op{
+		{Type: OpTypeUpdate, Collection: "app.bsky.feed.post", Rkey: &rkey, Record: rmPostRecord("v2")},
+		{Type: OpTypeDelete, Collection: "app.bsky.feed.post", Rkey: &rkey},
+	}, nil); err != nil {
+		t.Fatalf("applyWrites update+delete: %v", err)
+	}
+
+	if blockstoreHas(t, s, did, v1) {
+		t.Fatal("old record block still present after update+delete batch")
+	}
+	if _, ok := walkMstLeaves(t, s, did)["app.bsky.feed.post/r1"]; ok {
+		t.Fatal("record still in MST after update+delete batch")
+	}
+}
+
+// TestComputeRemovedCids unit-tests the diff helper directly.
+func TestComputeRemovedCids(t *testing.T) {
+	// mkcid builds a valid CIDv1 (dag-cbor, sha2-256) from arbitrary bytes.
+	mkcid := func(s string) cid.Cid {
+		pref := cid.NewPrefixV1(cid.DagCBOR, multihash.SHA2_256)
+		c, err := pref.Sum([]byte(s))
+		if err != nil {
+			t.Fatalf("sum: %v", err)
+		}
+		return c
+	}
+
+	// leaf returns the leaf CID a build() tree assigned to the given key.
+	leaf := func(key string) cid.Cid { return mkcid("leaf-" + key) }
+
+	build := func(keys ...string) *mst.Node {
+		tree := mst.NewEmptyTree()
+		for _, k := range keys {
+			if _, err := tree.Insert([]byte(k), leaf(k)); err != nil {
+				t.Fatalf("insert: %v", err)
+			}
+		}
+		if _, err := tree.RootCID(); err != nil {
+			t.Fatalf("root: %v", err)
+		}
+		return tree.Root
+	}
+
+	newRoot := mkcid("new-root")
+	prevRoot := mkcid("prev-root")
+	newBlock := mkcid("new-block")
+
+	t.Run("identical trees remove nothing", func(t *testing.T) {
+		n := build("app.bsky.feed.post/aaa")
+		removed := computeRemovedCids(n, n, nil, nil, newRoot)
+		if len(removed) != 0 {
+			t.Fatalf("expected no removals, got %v", removed)
+		}
+	})
+
+	t.Run("superseded node and prev commit removed", func(t *testing.T) {
+		prev := build("app.bsky.feed.post/aaa", "app.bsky.feed.post/bbb")
+		curr := build("app.bsky.feed.post/aaa", "app.bsky.feed.post/ccc")
+		removed := computeRemovedCids(prev, curr, []cid.Cid{prevRoot}, nil, newRoot)
+		set := map[cid.Cid]bool{}
+		for _, c := range removed {
+			set[c] = true
+		}
+		if !set[prevRoot] {
+			t.Fatalf("prev commit not removed: %v", removed)
+		}
+		if !set[leaf("app.bsky.feed.post/bbb")] {
+			t.Fatalf("bbb record block not removed: %v", removed)
+		}
+		// aaa's leaf (index 0) must be kept in both trees
+		if set[leaf("app.bsky.feed.post/aaa")] {
+			t.Fatalf("live leaf removed: %v", removed)
+		}
+	})
+
+	t.Run("unlinked new block removed", func(t *testing.T) {
+		n := build("app.bsky.feed.post/aaa")
+		removed := computeRemovedCids(n, n, nil, []cid.Cid{newBlock}, newRoot)
+		if len(removed) != 1 || removed[0] != newBlock {
+			t.Fatalf("expected only the unlinked new block removed, got %v", removed)
+		}
+	})
+
+	t.Run("new root always kept", func(t *testing.T) {
+		prev := build("app.bsky.feed.post/aaa")
+		curr := build("app.bsky.feed.post/aaa")
+		removed := computeRemovedCids(prev, curr, []cid.Cid{newRoot}, []cid.Cid{newRoot}, newRoot)
+		for _, c := range removed {
+			if c == newRoot {
+				t.Fatalf("new root removed: %v", removed)
+			}
+		}
+	})
+}
+
+// TestApplyWritesRepoStillVerifies asserts the repo opens, the MST verifies,
+// the commit signature verifies, and every record block is readable from the
+// blockstore after superseded blocks have been removed.
+func TestApplyWritesRepoStillVerifies(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	ctx := context.Background()
+
+	var ops []Op
+	rkeys := []string{"aaaa", "cccc", "eeee", "gggg", "iiii", "kkkk"}
+	for _, rk := range rkeys {
+		ops = append(ops, Op{
+			Type:       OpTypeCreate,
+			Collection: "app.bsky.feed.post",
+			Rkey:       &rk,
+			Record:     rmPostRecord(fmt.Sprintf("post %s", rk)),
+		})
+	}
+	mustApply(t, s, acct.Did, ops...)
+
+	// churn the tree so superseded blocks are actually created and removed
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeUpdate,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("cccc"),
+		Record:     rmPostRecord("updated"),
+	})
+	mustApply(t, s, acct.Did, Op{
+		Type:       OpTypeDelete,
+		Collection: "app.bsky.feed.post",
+		Rkey:       strPtr("gggg"),
+	})
+
+	root := currentRoot(t, s, acct.Did)
+	bs := s.getBlockstore(acct.Did)
+
+	r, err := openRepo(ctx, bs, root, acct.Did)
+	if err != nil {
+		t.Fatalf("open repo from current root: %v", err)
+	}
+
+	// MST structural verification
+	if err := r.MST.Verify(); err != nil {
+		t.Fatalf("mst verify: %v", err)
+	}
+
+	// commit signature verification
+	blk, err := bs.Get(ctx, root)
+	if err != nil {
+		t.Fatalf("get commit block: %v", err)
+	}
+	var commit atp.Commit
+	if err := commit.UnmarshalCBOR(bytes.NewReader(blk.RawData())); err != nil {
+		t.Fatalf("unmarshal commit: %v", err)
+	}
+	priv, err := atcrypto.ParsePrivateBytesK256(acct.SigningKey)
+	if err != nil {
+		t.Fatalf("parse private key: %v", err)
+	}
+	pub, err := priv.PublicKey()
+	if err != nil {
+		t.Fatalf("derive public key: %v", err)
+	}
+	if err := commit.VerifySignature(pub); err != nil {
+		t.Fatalf("commit signature verification failed: %v", err)
+	}
+	mstRoot, err := r.MST.RootCID()
+	if err != nil {
+		t.Fatalf("mst root: %v", err)
+	}
+	if commit.Data != *mstRoot {
+		t.Fatalf("commit data root %s does not match MST root %s", commit.Data, mstRoot)
+	}
+
+	// every leaf record block must still be readable
+	leaves := walkMstLeaves(t, s, acct.Did)
+	if len(leaves) != len(rkeys)-1 {
+		t.Fatalf("unexpected leaf count: %d", len(leaves))
+	}
+	for path, c := range leaves {
+		if _, err := bs.Get(ctx, c); err != nil {
+			t.Fatalf("record block %s for %s missing: %v", c, path, err)
+		}
+	}
+}

--- a/sqlite_blockstore/sqlite_blockstore.go
+++ b/sqlite_blockstore/sqlite_blockstore.go
@@ -46,13 +46,15 @@ func (bs *SqliteBlockstore) Get(ctx context.Context, cid cid.Cid) (blocks.Block,
 		return maybeBlock, nil
 	}
 
-	if err := bs.db.Raw(ctx, "SELECT * FROM blocks WHERE did = ? AND cid = ?", nil, bs.did, cid.Bytes()).Scan(&block).Error; err != nil {
-		return nil, err
+	result := bs.db.Raw(ctx, "SELECT * FROM blocks WHERE did = ? AND cid = ?", nil, bs.did, cid.Bytes()).Scan(&block)
+	if result.Error != nil {
+		return nil, result.Error
 	}
 
-	// GORM's Scan does not error when no rows match; treat a missing row as a
-	// not-found error so callers (eg partial MST loads) see proper semantics.
-	if len(block.Value) == 0 {
+	// GORM's Scan does not error when no rows match; use the row count as the
+	// existence signal (not payload length: a stored zero-length block is a
+	// hit) so callers (eg partial MST loads) see proper not-found semantics.
+	if result.RowsAffected == 0 {
 		return nil, ipld.ErrNotFound{
 			Cid: cid,
 		}

--- a/sqlite_blockstore/sqlite_blockstore.go
+++ b/sqlite_blockstore/sqlite_blockstore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/haileyok/cocoon/models"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
 	"gorm.io/gorm/clause"
 )
 
@@ -49,6 +50,14 @@ func (bs *SqliteBlockstore) Get(ctx context.Context, cid cid.Cid) (blocks.Block,
 		return nil, err
 	}
 
+	// GORM's Scan does not error when no rows match; treat a missing row as a
+	// not-found error so callers (eg partial MST loads) see proper semantics.
+	if len(block.Value) == 0 {
+		return nil, ipld.ErrNotFound{
+			Cid: cid,
+		}
+	}
+
 	b, err := blocks.NewBlockWithCid(block.Value, cid)
 	if err != nil {
 		return nil, err
@@ -81,8 +90,39 @@ func (bs *SqliteBlockstore) Put(ctx context.Context, block blocks.Block) error {
 	return nil
 }
 
-func (bs *SqliteBlockstore) DeleteBlock(context.Context, cid.Cid) error {
-	panic("not implemented")
+func (bs *SqliteBlockstore) DeleteBlock(ctx context.Context, c cid.Cid) error {
+	return bs.DeleteMany(ctx, []cid.Cid{c})
+}
+
+// DeleteMany removes the given blocks from the underlying storage. Blocks
+// that are not present are ignored (delete is idempotent), matching the
+// reference PDS behavior for removedCids.
+func (bs *SqliteBlockstore) DeleteMany(ctx context.Context, cids []cid.Cid) error {
+	if len(cids) == 0 {
+		return nil
+	}
+
+	if bs.readonly {
+		return fmt.Errorf("cannot delete from readonly blockstore")
+	}
+
+	did := bs.did
+	if err := bs.db.Transaction(ctx, func(tx *db.DB) error {
+		for _, c := range cids {
+			if err := tx.Exec(ctx, "DELETE FROM blocks WHERE did = ? AND cid = ?", nil, did, c.Bytes()).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	for _, c := range cids {
+		delete(bs.inserts, c)
+	}
+
+	return nil
 }
 
 func (bs *SqliteBlockstore) Has(context.Context, cid.Cid) (bool, error) {


### PR DESCRIPTION
## Summary
- Cocoon never deleted blocks superseded by a commit (old MST nodes, old record versions, historical commit blocks). Since `com.atproto.sync.getRepo` exports the whole block table, deleted records and prior record versions shipped in every repo export — for one real repo, 85% of a 407 MB export was unreachable data, including 758 deleted records and 52 previous profile versions.
- This copies the reference PDS (`@atproto/pds`) behavior: `applyCommit` deletes `commit.removedCids` when applying a commit, so the whole-table export is safe there. Cocoon now computes and deletes the equivalent set on every write.
- Adds a `gc-repos` command so existing repos can reclaim the strata already accumulated before this fix.

## Changes
- `server/repo.go`: `applyWrites` snapshots the pre-write MST, and after committing computes `removedCids` — superseded MST node blocks, record blocks no longer linked (updates/deletes), the previous commit block, and same-batch garbage (e.g. create+delete of one rkey in one batch, matching the reference `DataDiff` add/remove cancel-out) — then deletes them via `DeleteMany`. Deletion runs **after** the firehose event is published, because the `#commit` event CAR embeds the removed record block bytes so consumers can apply delete ops.
- `sqlite_blockstore`: `DeleteBlock` was `panic("not implemented")`; now implemented, plus a transactional, idempotent `DeleteMany`. `Get` now returns `ipld.ErrNotFound` when no row matches (previously GORM `Scan` silently returned an empty block), using `RowsAffected` as the existence signal.
- `recording_blockstore`: records deletions so removed blocks drop out of the write log.
- `server/repo_gc.go` + `cocoon gc-repos --dids ...`: one-shot migration that walks each repo's MST at its current head, collects every reachable CID (commit block, MST nodes, record blocks), and deletes every other block row. Dry-run by default, `--confirm` to apply (same shape as `recommit-repos`). The repo itself is never mutated — no new commit, no re-signing, no firehose events. Unparseable block CID rows fail the repo's pass rather than being guessed at.
- Compatibility note: historical commit blocks are now deleted, so fetching an old commit by CID returns not-found — same behavior as the official PDS. `TestApplyWritesEmitsPrevData` was adjusted to capture `prevData` before the write for this reason.
- The per-commit delete is not atomic with the block insert (TODO in code): a crash in between strands a superseded block — bloat, not corruption.

## Validation
- 9 new tests for the write path (record/MST/commit removal, shared-node retention, no-op updates, firehose CAR integrity after removals, full repo+MST+commit-signature verification, two batch-churn cases, unit test of `computeRemovedCids`).
- 7 new tests for the GC migration (dry-run fidelity, garbage removal with live blocks retained and repo still opening, already-clean repo, unknown DID, corrupt CID row aborting identically in dry-run and apply, missing live row producing no negative accounting, plus the same cases across both modes).
- `make test` — all packages pass.
- `go test -race ./...` — pass (CI parity).
- `go vet ./...` + `gofmt` — clean.
- Adversarial review (roast): three runs, each finding fixed and re-reviewed. (1) LOW: blockstore existence check conflated a missing row with a stored zero-length block — fixed in `614a990`. (2) MEDIUM: GC substituted `cid.Undef` for unparseable CID rows, which would not match the stored bytes — fixed in `ed063df` (corrupt rows now fail the repo's pass). (3) MEDIUM: GC computed removals by subtraction (could go negative when a live block row is missing) and dry-run skipped CID validation — fixed in `7ff4744` (dead blocks counted from actual rows; rows loaded and validated before the dry-run return). The final re-review of the last fix came back clean (run `20260910T215316Z-2f26da7d`).

## Review notes
- The write path keeps its existing non-atomicity profile; only the TODO'd insert→delete window is new.
- `gc-repos` should be run with the PDS stopped (a concurrent write would race the pass), and SQLite needs a `VACUUM` afterwards to return freed space to the OS — both stated in the command's help text.
- Reviewer focus areas: `computeRemovedCids` diff correctness, firehose ordering (event CAR built before deletion), the `Get` not-found semantics change, and the GC reachability walk.
