### PR TITLE
Include reachable MST nodes in #commit event CARs; atomically claim PLC email tokens

### DIFF
--- a/server/handle_identity_plc_parity_test.go
+++ b/server/handle_identity_plc_parity_test.go
@@ -355,6 +355,45 @@ func TestSignPlcOpValidTokenSignsUserRotationKeys(t *testing.T) {
 	}
 }
 
+// Reference parity: single-use token. Two concurrent requests that both
+// loaded the repo before either consumed the token (the request-local repo
+// snapshot is loaded per-request by middleware) must not BOTH succeed: the
+// token claim must be atomic, not check-then-consume. Roast R-d8c94f.
+func TestSignPlcOpTokenSingleUseUnderRace(t *testing.T) {
+	s := newTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	p := newPlcTestServer(t)
+	s.attachPlcClient(t, p)
+
+	s.setPlcOperationCode(t, acct.Did, "tok123")
+	p.log = identity.DidAuditLog{auditEntry(acct, "plc_operation")}
+	body, _ := json.Marshal(map[string]any{
+		"token":        "tok123",
+		"rotationKeys": []string{sampleUserKey, "did:key:zQ3shtCGgexistingRotation"},
+	})
+
+	// both contexts get the SAME pre-consumption repo snapshot, which is what
+	// two racing requests observe in production
+	c1, rec1 := newRequestContext(http.MethodPost, "/xrpc/com.atproto.identity.signPlcOperation", string(body), nil)
+	c1.Set("repo", mustRepoActor(t, s, acct.Did))
+	c2, rec2 := newRequestContext(http.MethodPost, "/xrpc/com.atproto.identity.signPlcOperation", string(body), nil)
+	c2.Set("repo", mustRepoActor(t, s, acct.Did))
+
+	if err := s.handleSignPlcOperation(c1); err != nil {
+		t.Fatalf("handler 1 error: %v", err)
+	}
+	if err := s.handleSignPlcOperation(c2); err != nil {
+		t.Fatalf("handler 2 error: %v", err)
+	}
+
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request should succeed, got %d", rec1.Code)
+	}
+	if rec2.Code == http.StatusOK {
+		t.Fatalf("second request with same token also succeeded: single-use violated (%d)", rec2.Code)
+	}
+}
+
 // Bad token: no signed op ('Token is invalid' in the reference).
 func TestSignPlcOpBadTokenRejected(t *testing.T) {
 	s := newTestServer(t)

--- a/server/handle_identity_sign_plc_operation.go
+++ b/server/handle_identity_sign_plc_operation.go
@@ -53,6 +53,24 @@ func (s *Server) handleSignPlcOperation(e echo.Context) error {
 		return helpers.ExpiredTokenError(e)
 	}
 
+	// Atomically claim (consume) the token BEFORE building the operation.
+	// The check above runs against this request's repo snapshot; a concurrent
+	// request with the same token would pass the same check. A conditional
+	// UPDATE that only matches the still-unconsumed, unexpired token ensures
+	// exactly one request wins (fail-closed: a signing failure burns the
+	// token, but the user can simply request a new one).
+	claimed := s.db.Client().Exec(
+		"UPDATE repos SET plc_operation_code = NULL, plc_operation_code_expires_at = NULL WHERE did = ? AND plc_operation_code = ? AND plc_operation_code_expires_at > ?",
+		repo.Repo.Did, req.Token, time.Now().UTC(),
+	)
+	if claimed.Error != nil {
+		logger.Error("error claiming plc operation token", "error", claimed.Error)
+		return helpers.ServerError(e, nil)
+	}
+	if claimed.RowsAffected != 1 {
+		return helpers.InvalidTokenError(e)
+	}
+
 	ctx := context.WithValue(e.Request().Context(), "skip-cache", true)
 	lastOp, lastCid, err := s.plcClient.GetLastOp(ctx, repo.Repo.Did)
 	if err != nil {
@@ -94,11 +112,6 @@ func (s *Server) handleSignPlcOperation(e echo.Context) error {
 
 	if err := s.plcClient.SignOp(k, &op); err != nil {
 		logger.Error("error signing plc operation", "error", err)
-		return helpers.ServerError(e, nil)
-	}
-
-	if err := s.db.Exec(ctx, "UPDATE repos SET plc_operation_code = NULL, plc_operation_code_expires_at = NULL WHERE did = ?", nil, repo.Repo.Did).Error; err != nil {
-		logger.Error("error updating repo", "error", err)
 		return helpers.ServerError(e, nil)
 	}
 

--- a/server/repo.go
+++ b/server/repo.go
@@ -360,6 +360,7 @@ func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []
 	var newroot cid.Cid
 	var rev string
 	var removedCids []cid.Cid
+	var eventMstNodes map[cid.Cid]struct{}
 
 	if err := rm.withRepo(ctx, urepo.Did, rootcid, func(r *atp.Repo) (cid.Cid, error) {
 		// Snapshot the pre-write tree so we can compute which blocks this
@@ -530,6 +531,21 @@ func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []
 		}
 		removedCids = computeRemovedCids(prevTree.Root, r.MST.Root, []cid.Cid{rootcid}, newBlocks, newroot)
 
+		// Capture the post-commit MST root and every MST node CID reachable
+		// from it. The #commit event CAR must let a consumer walk from the
+		// commit block to the MST root even when no MST node was rewritten
+		// this commit (eg a no-op delete) or when rewritten nodes reference
+		// clean sibling subtrees (eg merges after a delete).
+		mstRoot, mstRootErr := r.MST.RootCID()
+		if mstRootErr != nil {
+			return cid.Undef, mstRootErr
+		}
+		// seed with the root so the CAR always contains it even when the
+		// in-memory root node predates this commit (no CID computed above)
+		eventMstNodes = map[cid.Cid]struct{}{*mstRoot: {}}
+		mstLeaves := map[cid.Cid]struct{}{}
+		collectTreeBlocks(r.MST.Root, eventMstNodes, mstLeaves)
+
 		return newroot, nil
 	}); err != nil {
 		return nil, err
@@ -599,6 +615,40 @@ func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []
 	for _, blk := range bs.GetWriteLog() {
 		if _, err := carstore.LdWrite(buf, blk.Cid().Bytes(), blk.RawData()); err != nil {
 			return nil, err
+		}
+	}
+
+	// Complete the event CAR so a consumer holding only this CAR can walk
+	// from the commit block to the MST root (and invert the ops, like the
+	// Bluesky relay does). The write log only contains blocks written during
+	// this commit; when nothing was dirty (eg a no-op delete) or when new
+	// nodes reference clean sibling subtrees (eg merges after a delete),
+	// reachable MST nodes would otherwise be missing. Add any reachable MST
+	// node not already emitted above, fetched from the blockstore.
+	if len(eventMstNodes) > 0 {
+		written := map[cid.Cid]struct{}{newroot: {}}
+		for _, blk := range bs.GetWriteLog() {
+			written[blk.Cid()] = struct{}{}
+		}
+		for _, op := range ops {
+			if op.Value != nil {
+				written[*op.Value] = struct{}{}
+			}
+			if op.Prev != nil {
+				written[*op.Prev] = struct{}{}
+			}
+		}
+		for c := range eventMstNodes {
+			if _, ok := written[c]; ok {
+				continue
+			}
+			blk, err := dbs.Get(ctx, c)
+			if err != nil {
+				return nil, fmt.Errorf("completing event car with mst node %s: %w", c, err)
+			}
+			if _, err := carstore.LdWrite(buf, blk.Cid().Bytes(), blk.RawData()); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/server/repro_relay_consecutive_test.go
+++ b/server/repro_relay_consecutive_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/atproto/repo"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/events"
+)
+
+// TestReproRelayConsecutiveDeletes drives many consecutive single-record
+// deletes (the production pattern: every delete emits an event, each verified
+// exactly like the Bluesky relay does with VerifyCommitMessage), on a large
+// randomly-keyed tree, until the tree is empty — covering subtree merges and
+// root collapses.
+func TestReproRelayConsecutiveDeletes(t *testing.T) {
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+	did := acct.Did
+
+	const n = 150
+	clk := syntax.NewTIDClock(0)
+	rkeys := make([]string, n)
+	ops := make([]Op, 0, n)
+	for i := 0; i < n; i++ {
+		rkeys[i] = clk.Next().String()
+		ops = append(ops, Op{
+			Type:       OpTypeCreate,
+			Collection: "app.bsky.feed.post",
+			Rkey:       &rkeys[i],
+			Record:     rmPostRecord(fmt.Sprintf("post %d", i)),
+		})
+	}
+	mustApply(t, s, did, ops...)
+
+	evts, cancel, err := s.evtman.Subscribe(context.Background(), "test", func(*events.XRPCStreamEvent) bool { return true }, nil)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer cancel()
+
+	recv := func() *comatproto.SyncSubscribeRepos_Commit {
+		t.Helper()
+		select {
+		case e := <-evts:
+			if e.RepoCommit == nil {
+				t.Fatalf("expected #commit, got %+v", e)
+			}
+			return e.RepoCommit
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for #commit event")
+			return nil
+		}
+	}
+
+	verify := func(evt *comatproto.SyncSubscribeRepos_Commit, rk string) {
+		t.Helper()
+		msg := &comatproto.SyncSubscribeRepos_Commit{
+			Repo:     did,
+			Rev:      evt.Rev,
+			Since:    evt.Since,
+			Commit:   evt.Commit,
+			PrevData: evt.PrevData,
+			Blocks:   evt.Blocks,
+			Ops:      evt.Ops,
+			Time:     evt.Time,
+		}
+		if _, err := repo.VerifyCommitMessage(context.Background(), msg); err != nil {
+			t.Fatalf("relay verification failed for delete of %s (rev %s): %v", rk, evt.Rev, err)
+		}
+	}
+
+	// delete every record one commit at a time, in shuffled key order, so
+	// subtrees merge and the root collapses as the tree drains
+	order := make([]int, n)
+	for i := range order {
+		order[i] = i
+	}
+	// deterministic shuffle
+	shuffled := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		shuffled = append(shuffled, rkeys[(i*37)%n])
+	}
+
+	seen := map[string]bool{}
+	for _, rk := range shuffled {
+		if seen[rk] {
+			continue
+		}
+		seen[rk] = true
+		mustApply(t, s, did, Op{
+			Type:       OpTypeDelete,
+			Collection: "app.bsky.feed.post",
+			Rkey:       &rk,
+		})
+		evt := recv()
+		verify(evt, rk)
+	}
+}

--- a/server/repro_relay_fuzz_test.go
+++ b/server/repro_relay_fuzz_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/atproto/repo"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/events"
+)
+
+// TestReproRelayDeleteFuzz drives single-record deletes across a variety of
+// tree shapes (sizes, key distributions, collection prefixes), verifying each
+// #commit event exactly like the Bluesky relay (repo.VerifyCommitMessage).
+// It hunts for the root-trim case: a delete that collapses the root to a
+// single clean child whose CID was never written in this commit.
+func TestReproRelayDeleteFuzz(t *testing.T) {
+	collections := []string{
+		"app.bsky.feed.post",
+		"app.bsky.graph.follow",
+		"app.bsky.feed.like",
+		"com.example.custom",
+	}
+
+	for _, n := range []int{3, 5, 8, 13, 21, 34, 55, 89, 144, 233} {
+		n := n
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			s := newTestServer(t)
+			s.evtman = newTestEvtman(t)
+			s.repoman = NewRepoMan(s)
+			acct := s.createTestAccount(t, "alice.pds.test")
+			s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+			did := acct.Did
+
+			// spread records across collections with TID rkeys; varying the
+			// collection prefix varies MST heights and tree shapes
+			clk := syntax.NewTIDClock(0)
+			type keyRef struct {
+				collection string
+				rkey       string
+			}
+			var keys []keyRef
+			ops := make([]Op, 0, n)
+			for i := 0; i < n; i++ {
+				kr := keyRef{collection: collections[i%len(collections)], rkey: clk.Next().String()}
+				keys = append(keys, kr)
+				ops = append(ops, Op{
+					Type:       OpTypeCreate,
+					Collection: kr.collection,
+					Rkey:       &kr.rkey,
+					Record:     rmPostRecord(fmt.Sprintf("post %d", i)),
+				})
+			}
+			mustApply(t, s, did, ops...)
+
+			evts, cancel, err := s.evtman.Subscribe(context.Background(), "test", func(*events.XRPCStreamEvent) bool { return true }, nil)
+			if err != nil {
+				t.Fatalf("subscribe: %v", err)
+			}
+			defer cancel()
+
+			recv := func() *comatproto.SyncSubscribeRepos_Commit {
+				t.Helper()
+				select {
+				case e := <-evts:
+					if e.RepoCommit == nil {
+						t.Fatalf("expected #commit, got %+v", e)
+					}
+					return e.RepoCommit
+				case <-time.After(3 * time.Second):
+					t.Fatal("timed out waiting for #commit event")
+					return nil
+				}
+			}
+
+			// delete in an interleaved order (different collection round-robin)
+			// so different subtree shapes are hit on the way down
+			for i := 0; i < n; i++ {
+				kr := keys[(i*7)%n]
+				mustApply(t, s, did, Op{
+					Type:       OpTypeDelete,
+					Collection: kr.collection,
+					Rkey:       &kr.rkey,
+				})
+				evt := recv()
+				msg := &comatproto.SyncSubscribeRepos_Commit{
+					Repo:     did,
+					Rev:      evt.Rev,
+					Since:    evt.Since,
+					Commit:   evt.Commit,
+					PrevData: evt.PrevData,
+					Blocks:   evt.Blocks,
+					Ops:      evt.Ops,
+					Time:     evt.Time,
+				}
+				if _, err := repo.VerifyCommitMessage(context.Background(), msg); err != nil {
+					t.Fatalf("n=%d i=%d: relay verification failed for delete of %s/%s (rev %s): %v",
+						n, i, kr.collection, kr.rkey, evt.Rev, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- The Bluesky relay verifies every `#commit` event by loading the MST from the event's embedded CAR and inverting the ops (`repo.VerifyCommitMessage`). Cocoon's event CAR contained only the op blocks and the commit's write log (dirty MST nodes), so when nothing was dirty — a no-op delete, or a delete whose rewritten nodes reference clean sibling subtrees after a merge — the CAR could not be walked from the commit to the MST root, and the relay logged `failed to invert commit MST … reading MST from CAR file: ipld: could not find …`.
- This predates #145 (reproduced on `6972181`), but was masked: the relay could previously recover missing MST nodes by fetching them from the PDS because superseded blocks were never deleted. Now that commits delete their `removedCids`, the event CAR must be self-sufficient — which made the bug visible in production immediately after the #145 deploy.

## Changes
- `server/repo.go` (`applyWrites`): after writing the write log into the event CAR, add every MST node CID reachable from the post-commit root that the CAR doesn't already contain (op blocks, write log), fetched from the blockstore. This mirrors the reference PDS's `newBlocks` + `relevantBlocks` guarantee that the event CAR is walkable end-to-end.
- The reachable set is collected in-memory from the post-commit tree inside the `withRepo` callback (root CID + `collectTreeBlocks` over the full tree), so no extra blockstore reads are needed to determine the set — only to fetch blocks not already written this commit.
- No-op deletes still emit an event (existing behavior, unchanged); the CAR is now merely complete. Records present in the DB `records` table but missing from the MST (drift) take this path — noted below as a follow-up.

## Validation
- Two new regression tests, both failing on `main` before this fix and passing after:
  - `TestReproRelayDeleteFuzz`: single-record deletes across 10 tree shapes (3–233 records, 4 collections, interleaved delete order), every event verified with the relay's own `repo.VerifyCommitMessage`. On `main`, the no-op-delete case fails with the exact production error (`reading MST from CAR file: ipld: could not find …`).
  - `TestReproRelayConsecutiveDeletes`: 150 consecutive one-commit-at-a-time deletes draining a multi-level tree to empty (covers subtree merges and root collapses), each event relay-verified.
- `go test -race ./...` — all packages pass.
- `go vet ./...` + `gofmt` — clean.
- Adversarial review (roast, run `20260911T014628Z-cab90796`): zero confirmed findings; two candidate findings refuted by the verifier (event-shape concern; a claimed nil-deref on no-op deletes, killed by `IsDelete()` requiring `Prev != nil`).
- Also included: a fix for a roast-verified finding (R-d8c94f, MEDIUM, CWE-362, run `20260911T015130Z-6cc0079d`) in the PLC token flow that landed on `main` in `3b030bd`: `signPlcOperation` validated the emailed token against the request-local snapshot and only consumed it after signing, so two concurrent same-token requests could both succeed. The token is now claimed atomically before signing (conditional `UPDATE` + `RowsAffected == 1`, fail-closed). Regression test: two invocations sharing the same pre-consumption snapshot; the second is rejected. Re-reviewed clean (run `20260911T024543Z-f55306df`).

## Review notes
- Event CARs now carry all reachable MST nodes, slightly larger events for large repos; the spec expects consumers to ignore unneeded blocks, and the reference PDS ships a comparable set.
- The no-op-delete *event shape* (a `#commit` with a delete op and no `prev`, when the rkey isn't in the MST) is pre-existing and unchanged — arguably it should be rejected client-side instead of committing a no-op. Worth a follow-up if the drift observed in production is real.
- Production follow-up after deploy: the relay has cached failed verification at the offending revs; a `#sync` re-announcement (account re-activation emits one) will nudge it to re-ingest from the current head.
