### PR TITLE
Fix subscribeRepos disconnect deadlock and missing prev on update ops

### DIFF
--- a/server/handle_sync_subscribe_repos.go
+++ b/server/handle_sync_subscribe_repos.go
@@ -18,6 +18,16 @@ import (
 // frame. It is not fatal to the connection: the caller logs it and moves on.
 var errSkipEvent = errors.New("event has no subscribeRepos frame type")
 
+// wsWriteTimeout bounds how long a single frame write may block.
+//
+// The websocket write path is synchronous, and Upgrade clears the deadlines
+// net/http had set on the connection, so nothing bounds a write by default. A
+// relay that stays connected but stops reading fills the socket buffers and
+// blocks that write indefinitely — and a blocked write cannot be interrupted by
+// cancelling the context, so the handler would never reach its deferred
+// teardown. This is a var so tests can lower it.
+var wsWriteTimeout = 30 * time.Second
+
 // subscribeReposMsgType maps a stream event to its com.atproto.sync.subscribeRepos
 // message frame type and the object to serialize. The bool is false for events
 // that are not message frames (e.g. error frames, handled separately).
@@ -63,6 +73,12 @@ func writeEventFrame(conn *websocket.Conn, header *events.EventHeader, evt *even
 		header.Op = events.EvtKindMessage
 		header.MsgType = msgType
 		obj = o
+	}
+
+	// Bound the whole frame: NextWriter, the CBOR writes below and Close all
+	// flush through the same socket, and any of them can block on a stalled peer.
+	if err := conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout)); err != nil {
+		return "", fmt.Errorf("setting websocket write deadline: %w", err)
 	}
 
 	wc, err := conn.NextWriter(websocket.BinaryMessage)

--- a/server/handle_sync_subscribe_repos.go
+++ b/server/handle_sync_subscribe_repos.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -11,6 +13,10 @@ import (
 	"github.com/haileyok/cocoon/metrics"
 	"github.com/labstack/echo/v4"
 )
+
+// errSkipEvent marks an event that cannot be represented as a subscribeRepos
+// frame. It is not fatal to the connection: the caller logs it and moves on.
+var errSkipEvent = errors.New("event has no subscribeRepos frame type")
 
 // subscribeReposMsgType maps a stream event to its com.atproto.sync.subscribeRepos
 // message frame type and the object to serialize. The bool is false for events
@@ -32,6 +38,51 @@ func subscribeReposMsgType(evt *events.XRPCStreamEvent) (string, util.CBOR, bool
 	}
 }
 
+// writeEventFrame writes a single subscribeRepos frame — the CBOR event header
+// followed by the event body — to the relay connection, returning the message
+// type that was written (empty for error frames).
+//
+// btcsuite/websocket buffers each frame inside the connection and flushes it
+// only when the writer is closed. A writer abandoned without Close is flushed
+// by the *next* NextWriter call rather than discarded, so a partial frame would
+// reach the relay and be read as a malformed event. Every error path here
+// returns before Close and leaves the buffer untouched; the caller tears the
+// connection down so nothing stale is ever written.
+func writeEventFrame(conn *websocket.Conn, header *events.EventHeader, evt *events.XRPCStreamEvent) (string, error) {
+	var obj util.CBOR
+
+	if evt.Error != nil {
+		header.Op = events.EvtKindErrorFrame
+		header.MsgType = ""
+		obj = evt.Error
+	} else {
+		msgType, o, ok := subscribeReposMsgType(evt)
+		if !ok {
+			return "", errSkipEvent
+		}
+		header.Op = events.EvtKindMessage
+		header.MsgType = msgType
+		obj = o
+	}
+
+	wc, err := conn.NextWriter(websocket.BinaryMessage)
+	if err != nil {
+		return "", fmt.Errorf("opening websocket writer: %w", err)
+	}
+
+	if err := header.MarshalCBOR(wc); err != nil {
+		return "", fmt.Errorf("writing event header: %w", err)
+	}
+	if err := obj.MarshalCBOR(wc); err != nil {
+		return "", fmt.Errorf("writing event body: %w", err)
+	}
+	if err := wc.Close(); err != nil {
+		return "", fmt.Errorf("flushing event frame: %w", err)
+	}
+
+	return header.MsgType, nil
+}
+
 func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
 	ctx, cancel := context.WithCancel(e.Request().Context())
 	defer cancel()
@@ -47,6 +98,13 @@ func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
 	ident := e.RealIP() + "-" + e.Request().UserAgent()
 	logger = logger.With("ident", ident)
 	logger.Info("new connection established")
+
+	// Upgrade hijacks the connection, so net/http will never close it for us.
+	defer func() {
+		if err := conn.Close(); err != nil {
+			logger.Warn("error closing websocket", "err", err)
+		}
+	}()
 
 	var since *int64
 	if cursorStr := e.QueryParam("cursor"); cursorStr != "" {
@@ -89,52 +147,36 @@ func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
 	}()
 
 	header := events.EventHeader{Op: events.EvtKindMessage}
-	for evt := range evts {
-		func() {
-			defer func() {
-				metrics.RelaySends.WithLabelValues(ident, header.MsgType).Inc()
-			}()
 
-			wc, err := conn.NextWriter(websocket.BinaryMessage)
+forward:
+	for {
+		select {
+		case <-ctx.Done():
+			// The relay went away. The send loop cannot wait on the event
+			// channel alone: cancelling this context closes nothing, so
+			// evtManCancel — whose defer runs below, in this goroutine — would
+			// never run and the subscription would never be retired.
+			break forward
+		case evt, ok := <-evts:
+			if !ok {
+				// The event manager retired this subscription (e.g. a slow
+				// consumer); no further events will arrive.
+				break forward
+			}
+
+			msgType, err := writeEventFrame(conn, &header, evt)
 			if err != nil {
+				if errors.Is(err, errSkipEvent) {
+					logger.Warn("unrecognized event kind")
+					continue
+				}
+
 				logger.Error("error writing message to relay", "err", err)
-				return
+				break forward
 			}
 
-			if ctx.Err() != nil {
-				logger.Error("context error", "err", err)
-				return
-			}
-
-			var obj util.CBOR
-			if evt.Error != nil {
-				header.Op = events.EvtKindErrorFrame
-				header.MsgType = ""
-				obj = evt.Error
-			} else if msgType, o, ok := subscribeReposMsgType(evt); ok {
-				header.Op = events.EvtKindMessage
-				header.MsgType = msgType
-				obj = o
-			} else {
-				logger.Warn("unrecognized event kind")
-				return
-			}
-
-			if err := header.MarshalCBOR(wc); err != nil {
-				logger.Error("failed to write header to relay", "err", err)
-				return
-			}
-
-			if err := obj.MarshalCBOR(wc); err != nil {
-				logger.Error("failed to write event to relay", "err", err)
-				return
-			}
-
-			if err := wc.Close(); err != nil {
-				logger.Error("failed to flush-close our event write", "err", err)
-				return
-			}
-		}()
+			metrics.RelaySends.WithLabelValues(ident, msgType).Inc()
+		}
 	}
 
 	// we should tell the relay to request a new crawl at this point if we got disconnected

--- a/server/repo.go
+++ b/server/repo.go
@@ -579,11 +579,23 @@ func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []
 			}
 
 			ll := lexutil.LexLink(*op.Value)
-			repoOps = append(repoOps, &atproto.SyncSubscribeRepos_RepoOp{
+			repoOp := &atproto.SyncSubscribeRepos_RepoOp{
 				Action: kind,
 				Path:   op.Path,
 				Cid:    &ll,
-			})
+			}
+
+			// Updates must advertise the superseded record CID: the lexicon
+			// marks `prev` as required for update and delete frames, and
+			// consumers (including the relay's op parser) reject an update
+			// without it. A create has no previous value, so the field stays
+			// unset.
+			if op.IsUpdate() {
+				prev := lexutil.LexLink(*op.Prev)
+				repoOp.Prev = &prev
+			}
+
+			repoOps = append(repoOps, repoOp)
 
 			blk, err := dbs.Get(ctx, *op.Value)
 			if err != nil {

--- a/server/subscribe_repos_test.go
+++ b/server/subscribe_repos_test.go
@@ -1,0 +1,310 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/atproto/repo"
+	"github.com/bluesky-social/indigo/events"
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Regression tests for the com.atproto.sync.subscribeRepos websocket handler
+// (server/handle_sync_subscribe_repos.go) and the #commit op encoding
+// (server/repo.go).
+
+func handlerGoroutines() int {
+	buf := make([]byte, 1<<22)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), "(*Server).handleSyncSubscribeRepos(")
+}
+
+func gaugeRelaysConnected(t *testing.T) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	total := 0.0
+	for _, mf := range mfs {
+		if mf.GetName() != "cocoon_relays_connected" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			total += m.GetGauge().GetValue()
+		}
+	}
+	return total
+}
+
+func counterTotal(t *testing.T, name string) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	total := 0.0
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			total += m.GetCounter().GetValue()
+		}
+	}
+	return total
+}
+
+func newSubscribeTestServer(t *testing.T) *Server {
+	t.Helper()
+	s := newTestServer(t)
+	s.evtman = newTestEvtman(t)
+	s.repoman = NewRepoMan(s)
+	return s
+}
+
+// serveSubscribeRepos stands up a real HTTP server hosting the handler and
+// returns a dialer for it.
+func serveSubscribeRepos(t *testing.T, s *Server) func(ua string) *websocket.Conn {
+	t.Helper()
+
+	e := echo.New()
+	e.GET("/xrpc/com.atproto.sync.subscribeRepos", s.handleSyncSubscribeRepos)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: e}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	url := "ws://" + ln.Addr().String() + "/xrpc/com.atproto.sync.subscribeRepos"
+	return func(ua string) *websocket.Conn {
+		t.Helper()
+		hdr := http.Header{}
+		hdr.Set("User-Agent", ua)
+		c, _, err := websocket.DefaultDialer.Dial(url, hdr)
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		return c
+	}
+}
+
+func emitAccountEvent(s *Server) {
+	s.evtman.AddEvent(context.Background(), &events.XRPCStreamEvent{
+		RepoAccount: &comatproto.SyncSubscribeRepos_Account{
+			Active: true,
+			Did:    "did:plc:retire",
+			Time:   time.Now().Format(time.RFC3339),
+		},
+	})
+}
+
+// awaitFirstEvent pumps events until the connected client receives one, proving
+// the handler has registered its subscriber and is writing frames.
+func awaitFirstEvent(t *testing.T, s *Server, c *websocket.Conn) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		emitAccountEvent(s)
+		_ = c.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+		if _, _, err := c.ReadMessage(); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("client never received an event; harness broken")
+		}
+	}
+}
+
+// TestSubscribeReposRetiresSubscriberAfterDisconnect asserts the handler
+// unwinds and releases everything it holds once the relay goes away:
+//
+//   - the event-manager subscription stops receiving broadcasts,
+//   - the handler goroutine exits,
+//   - cocoon_relays_connected is decremented back to zero.
+//
+// Regression test for a deadlock: the send loop ranged over the event channel,
+// which is closed only by the deferred evtManCancel in that same goroutine, so
+// cancelling the request context never unwound it.
+func TestSubscribeReposRetiresSubscriberAfterDisconnect(t *testing.T) {
+	s := newSubscribeTestServer(t)
+	dial := serveSubscribeRepos(t, s)
+
+	c := dial("relay/1.0")
+	awaitFirstEvent(t, s, c)
+
+	if got := gaugeRelaysConnected(t); got != 1 {
+		t.Fatalf("connected: cocoon_relays_connected = %v, want 1", got)
+	}
+
+	// The relay goes away.
+	_ = c.Close()
+
+	// The handler must unwind on its own, without needing any further events
+	// to be broadcast.
+	deadline := time.Now().Add(10 * time.Second)
+	for handlerGoroutines() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("handler goroutine never unwound after disconnect: %d still parked", handlerGoroutines())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if got := gaugeRelaysConnected(t); got != 0 {
+		t.Errorf("cocoon_relays_connected = %v, want 0 (gauge must not accumulate across reconnects)", got)
+	}
+
+	// And the retired subscription must not keep absorbing broadcasts.
+	enqueuedBefore := counterTotal(t, "indigo_events_enqueued_for_broadcast_total")
+	for i := 0; i < 500; i++ {
+		emitAccountEvent(s)
+	}
+	time.Sleep(500 * time.Millisecond)
+	enqueuedAfter := counterTotal(t, "indigo_events_enqueued_for_broadcast_total")
+
+	if delta := enqueuedAfter - enqueuedBefore; delta != 0 {
+		t.Errorf("retired subscriber still receiving broadcasts: %.0f events enqueued after disconnect (want 0)", delta)
+	}
+}
+
+// TestSubscribeReposGaugeDoesNotAccumulateAcrossReconnects drives several
+// connect/disconnect cycles — the pattern a flapping relay produces — and
+// asserts the connection gauge returns to zero each time.
+func TestSubscribeReposGaugeDoesNotAccumulateAcrossReconnects(t *testing.T) {
+	s := newSubscribeTestServer(t)
+	dial := serveSubscribeRepos(t, s)
+
+	const cycles = 4
+	for i := 0; i < cycles; i++ {
+		c := dial("relay/1.0")
+		awaitFirstEvent(t, s, c)
+
+		if got := gaugeRelaysConnected(t); got != 1 {
+			t.Fatalf("cycle %d connected: cocoon_relays_connected = %v, want 1", i+1, got)
+		}
+
+		_ = c.Close()
+
+		deadline := time.Now().Add(10 * time.Second)
+		for gaugeRelaysConnected(t) != 0 {
+			if time.Now().After(deadline) {
+				t.Fatalf("cycle %d: gauge stuck at %v after disconnect, want 0", i+1, gaugeRelaysConnected(t))
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	if n := handlerGoroutines(); n != 0 {
+		t.Errorf("%d handler goroutine(s) leaked across %d reconnect cycles", n, cycles)
+	}
+}
+
+// TestCommitUpdateOpCarriesPrev asserts #commit frames advertise the superseded
+// record CID for updates, as the lexicon requires, and that its absence no
+// longer causes the relay's verifier to skip prevData/MST inversion.
+func TestCommitUpdateOpCarriesPrev(t *testing.T) {
+	s := newSubscribeTestServer(t)
+	acct := s.createTestAccount(t, "alice.pds.test")
+	s.seedGenesisRepo(t, acct.Did, acct.SigningKey)
+
+	ctx := context.Background()
+	urepo, err := s.getRepoActorByDid(ctx, acct.Did)
+	if err != nil {
+		t.Fatalf("getRepoActorByDid: %v", err)
+	}
+
+	evts, cancel, err := s.evtman.Subscribe(ctx, "test", func(*events.XRPCStreamEvent) bool { return true }, nil)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	defer cancel()
+
+	recvCommit := func() *comatproto.SyncSubscribeRepos_Commit {
+		t.Helper()
+		for {
+			select {
+			case e := <-evts:
+				if e.RepoCommit != nil {
+					return e.RepoCommit
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("timed out waiting for #commit")
+			}
+		}
+	}
+
+	rkey := "3laaaaaaaaa2x"
+	rec := MarshalableMap{"$type": "app.bsky.feed.post", "text": "v1", "createdAt": "2024-01-01T00:00:00Z"}
+	if _, err := s.repoman.applyWrites(ctx, urepo.Repo, []Op{{
+		Type: OpTypeCreate, Collection: "app.bsky.feed.post", Rkey: &rkey, Record: &rec,
+	}}, nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	createEvt := recvCommit()
+	if len(createEvt.Ops) != 1 {
+		t.Fatalf("create event ops = %d, want 1", len(createEvt.Ops))
+	}
+	if got := createEvt.Ops[0]; got.Action != "create" {
+		t.Fatalf("op action = %q, want %q", got.Action, "create")
+	} else if got.Prev != nil {
+		t.Errorf("create op must not carry prev, got %v", got.Prev)
+	}
+	createdCid := *createEvt.Ops[0].Cid
+
+	urepo, err = s.getRepoActorByDid(ctx, acct.Did)
+	if err != nil {
+		t.Fatalf("reload repo: %v", err)
+	}
+	rec2 := MarshalableMap{"$type": "app.bsky.feed.post", "text": "v2", "createdAt": "2024-01-01T00:00:01Z"}
+	if _, err := s.repoman.applyWrites(ctx, urepo.Repo, []Op{{
+		Type: OpTypeUpdate, Collection: "app.bsky.feed.post", Rkey: &rkey, Record: &rec2,
+	}}, nil); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	updEvt := recvCommit()
+
+	if len(updEvt.Ops) != 1 {
+		t.Fatalf("update event ops = %d, want 1", len(updEvt.Ops))
+	}
+	op := updEvt.Ops[0]
+	if op.Action != "update" {
+		t.Fatalf("op action = %q, want %q", op.Action, "update")
+	}
+	if op.Prev == nil {
+		t.Fatal("update op carries no prev CID; the lexicon requires it for updates")
+	}
+	if *op.Prev != createdCid {
+		t.Errorf("update op prev = %v, want the superseded record CID %v", *op.Prev, createdCid)
+	}
+	if op.Cid == nil || *op.Cid == *op.Prev {
+		t.Errorf("update op cid = %v, want a CID distinct from prev %v", op.Cid, *op.Prev)
+	}
+
+	// The relay's own verification path must now run the prevData/MST
+	// inversion rather than bailing out on a legacy-shaped op.
+	msg := &comatproto.SyncSubscribeRepos_Commit{
+		Repo:     acct.Did,
+		Rev:      updEvt.Rev,
+		Since:    updEvt.Since,
+		Commit:   updEvt.Commit,
+		PrevData: updEvt.PrevData,
+		Blocks:   updEvt.Blocks,
+		Ops:      updEvt.Ops,
+		Time:     updEvt.Time,
+	}
+	if _, err := repo.VerifyCommitMessage(ctx, msg); err != nil {
+		t.Fatalf("relay-style verification of the update commit failed: %v", err)
+	}
+}

--- a/server/subscribe_repos_test.go
+++ b/server/subscribe_repos_test.go
@@ -210,6 +210,119 @@ func TestSubscribeReposGaugeDoesNotAccumulateAcrossReconnects(t *testing.T) {
 	}
 }
 
+// wedgedPeer opens a websocket connection by hand, reads only the handshake
+// response, and then stops reading forever without setting a deadline on its
+// socket.
+//
+// This is the "stalled consumer" a reader error cannot detect: TCP stays
+// healthy and open (the peer's receive window simply closes), so the server's
+// read goroutine never errors, while the server's writes block once the socket
+// buffers fill. A polling client from a library is unsuitable here — it sets
+// read deadlines, and once it becomes unreachable its finalizer closes the
+// socket, which the server observes as an ordinary disconnect instead.
+//
+// The returned conn must be kept reachable (runtime.KeepAlive) for the duration
+// of the test, or the finalizer will close it.
+func wedgedPeer(t *testing.T, addr string) net.Conn {
+	t.Helper()
+
+	nc, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial tcp: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/xrpc/com.atproto.sync.subscribeRepos", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Sec-WebSocket-Version", "13")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	req.Header.Set("User-Agent", "relay/wedged-peer")
+
+	if err := req.Write(nc); err != nil {
+		t.Fatalf("write handshake: %v", err)
+	}
+
+	// Read just the handshake response, then never read again.
+	_ = nc.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 4096)
+	if _, err := nc.Read(buf); err != nil {
+		t.Fatalf("read handshake response: %v", err)
+	}
+	_ = nc.SetReadDeadline(time.Time{})
+
+	return nc
+}
+
+// TestSubscribeReposWriteDeadlineUnwindsOnWedgedPeer covers the failure a reader
+// error cannot detect: a relay that stays connected but stops reading. The
+// socket buffers fill, the synchronous frame write blocks, and no read error
+// fires — so only a write deadline can unpin the handler.
+//
+// Regression test for a handler that stayed blocked inside the write path
+// forever, never reaching its deferred evtManCancel/conn.Close.
+func TestSubscribeReposWriteDeadlineUnwindsOnWedgedPeer(t *testing.T) {
+	defer func(prev time.Duration) { wsWriteTimeout = prev }(wsWriteTimeout)
+	wsWriteTimeout = 1 * time.Second
+
+	s := newSubscribeTestServer(t)
+
+	e := echo.New()
+	e.GET("/xrpc/com.atproto.sync.subscribeRepos", s.handleSyncSubscribeRepos)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: e}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	nc := wedgedPeer(t, ln.Addr().String())
+	defer func() {
+		runtime.KeepAlive(nc)
+		_ = nc.Close()
+	}()
+
+	// Wait for the server to register the subscriber. The peer is not reading,
+	// so we cannot wait on a received event.
+	deadline := time.Now().Add(10 * time.Second)
+	for handlerGoroutines() == 0 {
+		emitAccountEvent(s)
+		if time.Now().After(deadline) {
+			t.Fatal("handler never registered a subscriber")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Flood payloads large enough to fill the socket buffers and block the
+	// server's write. The handler must unpin itself via the write deadline.
+	big := strings.Repeat("x", 256*1024)
+	unpinBy := time.Now().Add(30 * time.Second)
+	for i := 0; i < 20000; i++ {
+		s.evtman.AddEvent(context.Background(), &events.XRPCStreamEvent{
+			RepoAccount: &comatproto.SyncSubscribeRepos_Account{
+				Active: true,
+				Did:    "did:plc:wedged",
+				Status: &big,
+				Time:   time.Now().Format(time.RFC3339),
+			},
+		})
+
+		if handlerGoroutines() == 0 {
+			break
+		}
+		if time.Now().After(unpinBy) {
+			t.Fatalf("handler still pinned by a non-reading peer: a blocked write must not outlive the write deadline")
+		}
+	}
+
+	if got := gaugeRelaysConnected(t); got != 0 {
+		t.Errorf("cocoon_relays_connected = %v, want 0 after the wedged peer forced a teardown", got)
+	}
+}
+
 // TestCommitUpdateOpCarriesPrev asserts #commit frames advertise the superseded
 // record CID for updates, as the lexicon requires, and that its absence no
 // longer causes the relay's verifier to skip prevData/MST inversion.


### PR DESCRIPTION
## Summary
- Fix a deadlock in the `com.atproto.sync.subscribeRepos` websocket handler: it never unwound after a relay disconnected, so subscriptions, goroutines and the connection gauge accumulated forever and the disconnect-triggered `requestCrawl` never ran.
- Bound frame writes with a write deadline so a relay that stays connected but stops reading can no longer pin the handler indefinitely.
- Fix `#commit` frames advertising updates without `repoOp.prev`, which is required by the lexicon and caused the relay to silently skip `prevData`/MST-inversion verification.
- Add regression tests covering subscriber retirement, gauge accounting across reconnects, stalled-consumer teardown, and update-op encoding.

## Changes

### `server/handle_sync_subscribe_repos.go`
- The send loop now `select`s on `ctx.Done()` as well as the event channel. Previously it ranged over a channel that is closed only by the deferred `evtManCancel` in the *same* goroutine, so cancelling the request context could never unwind it:
  - the event-manager subscription was never retired and was enqueued every subsequent broadcast, holding its buffer and a goroutine indefinitely;
  - `cocoon_relays_connected` was never decremented, so the gauge grew by one per relay reconnect and only ever went up;
  - the post-loop `s.requestCrawl()` — the entire purpose of the disconnect handling — was unreachable, so a flapping relay never triggered a crawl request.
- Close the hijacked websocket explicitly via `defer conn.Close()`. `websocket.Upgrade` hijacks the connection, so `net/http` never closes it for the caller; nothing in the handler previously did so.
- Set a `wsWriteTimeout` (30s) write deadline around each frame. The write path is synchronous and `Upgrade` clears the deadlines `net/http` had installed, so a peer that stays connected but stops reading fills the socket buffers and blocks the write — with no read error to detect it, and no way for context cancellation to interrupt it. `NextWriter`, the CBOR writes and `Close` all flush through the same socket, so the deadline covers the whole frame. `wsWriteTimeout` is a var so tests can lower it.
- Extracted frame writing into `writeEventFrame`. This also removes an abandoned-writer hazard: `btcsuite/websocket` flushes a pending frame on the *next* `NextWriter`, so early returns that left a writer unclosed could emit a partial frame for the relay to parse as a malformed event. All error paths now return before `Close` and the caller tears the connection down.
- `context error` log line previously passed the wrong `err` (the value from `NextWriter`); the send loop now reports the actual failure.

### `server/repo.go`
- `#commit` repo ops now set `prev` for updates, mirroring the existing delete branch. The operation's superseded CID is already available from `atp.ApplyOp`, so no extra lookups are needed. Creates correctly leave `prev` unset.
- Impact beyond spec compliance: with `prev` nil, the relay's `repo.VerifyCommitMessage` hits its legacy bail-out and skips the `prevData` / MST-inversion check entirely, so the inductive-firehose verification was a no-op for any repo that had ever updated a record.

### `server/subscribe_repos_test.go` (new)
- `TestSubscribeReposRetiresSubscriberAfterDisconnect` — after the peer disconnects, asserts the handler goroutine exits without needing further broadcasts, the gauge returns to 0, and no events are enqueued to the retired subscriber.
- `TestSubscribeReposGaugeDoesNotAccumulateAcrossReconnects` — four connect/disconnect cycles; asserts the gauge returns to 0 each time and no handler goroutines leak.
- `TestSubscribeReposWriteDeadlineUnwindsOnWedgedPeer` — drives a raw non-reading peer (handshake by hand, then stops reading with no socket deadline) and floods large payloads; asserts the handler unpins itself rather than blocking forever. A client built on a websocket library is unsuitable here: once it becomes unreachable its finalizer closes the socket, which the server observes as an ordinary disconnect rather than a stall, so the test would silently lose its teeth.
- `TestCommitUpdateOpCarriesPrev` — asserts create ops carry no `prev`, update ops carry the superseded CID (matching the created record's CID), and the resulting frame passes the relay's own `repo.VerifyCommitMessage`.

## Validation
- `go vet ./...` — clean.
- `gofmt -l server/` — clean.
- `make test` — full suite passes.
- `go test -race ./...` — passes (`ok github.com/haileyok/cocoon/server 11.928s`, plus helpers, oauth/client, oauth/scopes).
- Every new test was confirmed to **fail against the corresponding unpatched code**, by reverting the fix and re-running:
  - `TestSubscribeReposRetiresSubscriberAfterDisconnect`: `handler goroutine never unwound after disconnect: 1 still parked`
  - `TestSubscribeReposGaugeDoesNotAccumulateAcrossReconnects`: `cycle 1 connected: cocoon_relays_connected = 2, want 1`
  - `TestSubscribeReposWriteDeadlineUnwindsOnWedgedPeer`: `handler still pinned by a non-reading peer` (hangs for the full 30s budget)
  - `TestCommitUpdateOpCarriesPrev`: `update op carries no prev CID; the lexicon requires it for updates`
- Pre-fix measurement of the leak: after one relay disconnect, all 500 subsequent broadcasts were still enqueued to the dead subscriber; the handler goroutine remained parked on `for evt := range evts`.

## Review notes
- The `#info` frame mapping is retained, but nothing in cocoon emits `RepoInfo` events, and there is no `OutdatedCursor` emission when a requested cursor falls outside the 72h event retention window. A relay resuming from an aged cursor silently gets nothing rather than the lexicon's `OutdatedCursor` error frame. Left as-is for a separate change; worth a follow-up.
- `ident` is still `RealIP() + UserAgent`, so two relays behind one egress IP with the same UA share a metric label and are indistinguishable in `cocoon_relays_connected`.
- Atomic `activateAccount` emits `#account` then `#sync` from separate `AddEvent` calls, so a failure between them leaves the stream with the account event but no head announcement.
- There is still no read deadline or ping on the relay socket, so a half-open TCP connection (peer vanishes with no FIN) is not detected until a write fails or the event manager evicts the subscriber. The write deadline added here bounds the damage a silent peer can do to the handler; detecting it proactively would be a separate change.
