### PR TITLE
Keep subscribeRepos streams alive and close them gracefully

### DIFF
--- a/server/handle_sync_subscribe_repos.go
+++ b/server/handle_sync_subscribe_repos.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"time"
 
@@ -27,6 +28,21 @@ var errSkipEvent = errors.New("event has no subscribeRepos frame type")
 // cancelling the context, so the handler would never reach its deferred
 // teardown. This is a var so tests can lower it.
 var wsWriteTimeout = 30 * time.Second
+
+// Keepalive settings.
+//
+// A subscribeRepos stream can be silent for a long time — an idle PDS emits
+// nothing at all — and while it is silent nothing on the wire holds the
+// connection open. Middleboxes drop idle websockets, and a consumer's liveness
+// check only resets when it hears a pong, so a quiet host looks dead to both.
+// The handler therefore pings on an interval, and treats a peer that has
+// stopped answering as gone.
+//
+// These are vars so tests can lower them.
+var (
+	wsPingInterval = 30 * time.Second
+	wsPongTimeout  = 90 * time.Second
+)
 
 // subscribeReposMsgType maps a stream event to its com.atproto.sync.subscribeRepos
 // message frame type and the object to serialize. The bool is false for events
@@ -116,11 +132,57 @@ func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
 	logger.Info("new connection established")
 
 	// Upgrade hijacks the connection, so net/http will never close it for us.
+	// Send a close frame first: a bare TCP close is indistinguishable from a
+	// crash on the peer's side — the relay logs it as "close 1006 (abnormal
+	// closure)" — which turns a routine teardown into an apparent outage.
 	defer func() {
+		if err := conn.WriteControl(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseGoingAway, ""),
+			time.Now().Add(wsWriteTimeout)); err != nil && !errors.Is(err, websocket.ErrCloseSent) {
+			logger.Warn("error sending websocket close frame", "err", err)
+		}
 		if err := conn.Close(); err != nil {
 			logger.Warn("error closing websocket", "err", err)
 		}
 	}()
+
+	// A subscribeRepos stream can be silent for minutes: an idle PDS emits
+	// nothing at all. Two things follow, and both are handled here.
+	//
+	// First, the handler must keep the connection observably alive. A websocket
+	// carrying no traffic in either direction gets dropped by middleboxes, and a
+	// consumer reads the silence as a dead host. The send loop pings on
+	// wsPingInterval below.
+	//
+	// Second, the handler must notice a peer that has stopped answering. The
+	// read deadline is refreshed by anything the peer sends — pong, ping or data
+	// — and our own pings guarantee a live peer answers within one interval, so
+	// silence for wsPongTimeout means the peer is gone even though TCP has not
+	// noticed. A half-open connection (no FIN) produces no read error of its own,
+	// so without this the handler would sit on a dead socket indefinitely.
+	if err := conn.SetReadDeadline(time.Now().Add(wsPongTimeout)); err != nil {
+		return err
+	}
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(wsPongTimeout))
+	})
+	// Mirrors the ping handler indigo's own relay uses downstream: keep
+	// answering pings, and treat transient write failures as survivable rather
+	// than tearing the stream down on a moment's contention.
+	conn.SetPingHandler(func(message string) error {
+		if err := conn.SetReadDeadline(time.Now().Add(wsPongTimeout)); err != nil {
+			return err
+		}
+		err := conn.WriteControl(websocket.PongMessage, []byte(message),
+			time.Now().Add(wsWriteTimeout))
+		if errors.Is(err, websocket.ErrCloseSent) {
+			return nil
+		}
+		if e, ok := err.(net.Error); ok && e.Temporary() {
+			return nil
+		}
+		return err
+	})
 
 	var since *int64
 	if cursorStr := e.QueryParam("cursor"); cursorStr != "" {
@@ -164,6 +226,9 @@ func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
 
 	header := events.EventHeader{Op: events.EvtKindMessage}
 
+	ping := time.NewTicker(wsPingInterval)
+	defer ping.Stop()
+
 forward:
 	for {
 		select {
@@ -173,6 +238,15 @@ forward:
 			// evtManCancel — whose defer runs below, in this goroutine — would
 			// never run and the subscription would never be retired.
 			break forward
+		case <-ping.C:
+			// Keep the stream observably alive; see the keepalive comment above.
+			// A failed ping is not itself fatal — the read deadline is what
+			// reaps a peer that has stopped answering, and a momentary write
+			// failure should not tear down an otherwise healthy stream.
+			if err := conn.WriteControl(websocket.PingMessage, nil,
+				time.Now().Add(wsWriteTimeout)); err != nil {
+				logger.Warn("error pinging relay", "err", err)
+			}
 		case evt, ok := <-evts:
 			if !ok {
 				// The event manager retired this subscription (e.g. a slow

--- a/server/subscribe_repos_test.go
+++ b/server/subscribe_repos_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -320,6 +321,139 @@ func TestSubscribeReposWriteDeadlineUnwindsOnWedgedPeer(t *testing.T) {
 
 	if got := gaugeRelaysConnected(t); got != 0 {
 		t.Errorf("cocoon_relays_connected = %v, want 0 after the wedged peer forced a teardown", got)
+	}
+}
+
+// TestSubscribeReposPingsAnIdleStream asserts the handler keeps a silent stream
+// observably alive on its own schedule. An idle PDS emits nothing, and a
+// websocket carrying no traffic in either direction is dropped by middleboxes —
+// and read as a dead host by a consumer whose liveness check only resets on a
+// pong. Without server-initiated pings, a quiet cocoon is indistinguishable
+// from a down one.
+func TestSubscribeReposPingsAnIdleStream(t *testing.T) {
+	defer func(prev time.Duration) { wsPingInterval = prev }(wsPingInterval)
+	wsPingInterval = 200 * time.Millisecond
+
+	s := newSubscribeTestServer(t)
+	dial := serveSubscribeRepos(t, s)
+
+	c := dial("relay/idle-ping")
+	defer c.Close()
+
+	// Record pings as they arrive. A read timeout is fatal on a gorilla client
+	// (a second read panics), so this blocks on one read while control frames
+	// are dispatched to the handler.
+	var pings atomic.Int32
+	c.SetPingHandler(func(string) error {
+		pings.Add(1)
+		return nil
+	})
+
+	// No events are emitted at all: the ping must arrive on its own.
+	_ = c.SetReadDeadline(time.Now().Add(10 * time.Second))
+	_, _, _ = c.ReadMessage()
+
+	if got := pings.Load(); got == 0 {
+		t.Fatal("idle stream received no ping; a silent connection would be dropped upstream")
+	}
+}
+
+// TestSubscribeReposClosesGracefully asserts the handler sends a websocket close
+// frame before tearing the connection down.
+//
+// A bare TCP close carries no close code, so the peer surfaces it as
+// "close 1006 (abnormal closure): unexpected EOF" — the same shape as a crash.
+// A routine teardown must look like a normal going-away instead.
+//
+// The teardown here is server-initiated: the client handshakes and then never
+// answers a ping, so the handler reaps it. That path exists only because the
+// read deadline is enforced, and the close frame exists only because the
+// teardown announces itself.
+func TestSubscribeReposClosesGracefully(t *testing.T) {
+	defer func(pi, pt time.Duration) {
+		wsPingInterval, wsPongTimeout = pi, pt
+	}(wsPingInterval, wsPongTimeout)
+	wsPingInterval = 150 * time.Millisecond
+	wsPongTimeout = 500 * time.Millisecond
+
+	s := newSubscribeTestServer(t)
+	dial := serveSubscribeRepos(t, s)
+
+	c := dial("relay/graceful-close")
+	defer c.Close()
+
+	awaitFirstEvent(t, s, c)
+
+	// Stay silent: read frames, but never answer the server's pings.
+	c.SetPingHandler(func(string) error { return nil })
+
+	_ = c.SetReadDeadline(time.Now().Add(20 * time.Second))
+	for {
+		mt, _, err := c.ReadMessage()
+		if err != nil {
+			if websocket.IsCloseError(err, websocket.CloseGoingAway) {
+				return // close frame arrived — correct
+			}
+			t.Fatalf("connection dropped without a close frame (relay would log 1006): %v", err)
+		}
+		if mt == websocket.CloseMessage {
+			return
+		}
+	}
+}
+
+// TestSubscribeReposDetectsSilentPeer asserts a half-open connection is
+// reaped. A peer that vanishes without a FIN produces no read error of its own,
+// so only an unanswered ping — and the resulting read-deadline expiry — reveals
+// that it is gone. Without this the handler sits on a dead socket, holding its
+// event-manager subscription open indefinitely.
+func TestSubscribeReposDetectsSilentPeer(t *testing.T) {
+	defer func(pi, pt time.Duration) {
+		wsPingInterval, wsPongTimeout = pi, pt
+	}(wsPingInterval, wsPongTimeout)
+	wsPingInterval = 150 * time.Millisecond
+	wsPongTimeout = 500 * time.Millisecond
+
+	s := newSubscribeTestServer(t)
+
+	e := echo.New()
+	e.GET("/xrpc/com.atproto.sync.subscribeRepos", s.handleSyncSubscribeRepos)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{Handler: e}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	// Handshake, then go silent: never answer a ping, never send anything.
+	nc := wedgedPeer(t, ln.Addr().String())
+	defer func() {
+		runtime.KeepAlive(nc)
+		_ = nc.Close()
+	}()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for handlerGoroutines() == 0 {
+		emitAccountEvent(s)
+		if time.Now().After(deadline) {
+			t.Fatal("handler never registered a subscriber")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// The silent peer must be reaped once its pongs stop arriving, with no
+	// in-band signal of any kind to prompt it.
+	reaped := time.Now().Add(15 * time.Second)
+	for handlerGoroutines() != 0 {
+		if time.Now().After(reaped) {
+			t.Fatal("handler never reaped a silent peer: an unanswered ping must expire the read deadline")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if got := gaugeRelaysConnected(t); got != 0 {
+		t.Errorf("cocoon_relays_connected = %v, want 0 after a silent peer was reaped", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix the relay's `close 1006 (abnormal closure): unexpected EOF` on `subscribeRepos` by keeping the stream alive and announcing teardown.
- An idle cocoon emits nothing, and the handler sent nothing either, so the connection carried no traffic in either direction — which gets it reaped.

## Changes
- **Ping on an interval (`wsPingInterval`, 30s).** Keeps the stream observably alive in both directions. Mirrors what indigo's own relay does downstream of its consumers (`cmd/relay/relay/broadcast.go`), including a ping handler that tolerates transient write failures instead of tearing the stream down.
- **Expire the read deadline (`wsPongTimeout`, 90s), refreshed by any inbound frame.** A half-open connection (no FIN) produces no read error of its own, so without this the handler parks on a dead socket and holds its event-manager subscription open indefinitely. This is the same class of permanent pin as the earlier deadlock, reached through a different door.
- **Send a close frame before `conn.Close()`.** `Upgrade` hijacks the connection, so a bare close carries no close code and the consumer reports it as `close 1006 (abnormal closure): unexpected EOF` — a routine teardown that is indistinguishable from a crash.

## Validation
Measured against the live instance (`cocoon.hailey.at`, running `221c90b`) before writing the fix:

| Probe | Traffic | Result |
|---|---|---|
| Idle, no pings | none | **abrupt EOF at ~125s**, no close frame |
| Ping every 30s | ping/pong | alive 40+ minutes |
| Ping every 20s | ping/pong | alive 10 min (test window) |
| Real relay read path (`cmd/relay/stream.HandleRepoStream`) | relay's own pings | stayed connected; `events=0` |

The first row reproduces the relay's exact symptom, including the missing close frame. The handler previously never transmitted anything on an idle stream, so it sat in the first row.

Tests (`go vet`, `gofmt`, `make test`, `go test -race ./...` all clean):
- `TestSubscribeReposPingsAnIdleStream`
- `TestSubscribeReposClosesGracefully`
- `TestSubscribeReposDetectsSilentPeer`

All three **fail against the unpatched handler** — verified by stripping the fix and re-running, so they are genuine regression tests rather than tests written to match current behavior.

## Review notes
- `wsPingInterval` / `wsPongTimeout` are vars so tests can lower them; both are tunable if 30s/90s proves wrong for a slow-but-legitimate peer.
- This does not address the relay's **cursor** (`1770283459`, frozen since 2026-02-05, far outside the 72h retention window). With a cursor that old, `Playback` legitimately returns nothing and the stream stays silent until a new event is written — which is why the relay sees `events=0` on every reconnect. That is a separate issue from the teardown, and worth its own change; the `OutdatedCursor` error frame the lexicon defines for this case is still not emitted.
- Follow-ups from the previous PR that remain open: `ident` collisions between same-UA peers behind one IP, and `activateAccount` emitting `#account`/`#sync` as separate non-atomic `AddEvent` calls.
