### PR TITLE
Signal out-of-range cursors on subscribeRepos

### DIFF
--- a/server/firehose_sync_test.go
+++ b/server/firehose_sync_test.go
@@ -18,7 +18,10 @@ import (
 	gormlogger "gorm.io/gorm/logger"
 )
 
-func newTestEvtman(t *testing.T) *events.EventManager {
+// newTestEvtmanPersister builds an event manager over a fresh events database
+// and returns the persister alongside it, for tests that need to inspect the
+// retained seq range the manager prunes.
+func newTestEvtmanPersister(t *testing.T) (*events.EventManager, *DbPersister) {
 	t.Helper()
 	gdb, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "events.db")), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormlogger.Silent),
@@ -30,7 +33,13 @@ func newTestEvtman(t *testing.T) *events.EventManager {
 	if err != nil {
 		t.Fatalf("new persister: %v", err)
 	}
-	return events.NewEventManager(p)
+	return events.NewEventManager(p), p
+}
+
+func newTestEvtman(t *testing.T) *events.EventManager {
+	t.Helper()
+	m, _ := newTestEvtmanPersister(t)
+	return m
 }
 
 // seedGenesisRepo commits an empty repo for did and records it as the head.

--- a/server/handle_sync_subscribe_repos.go
+++ b/server/handle_sync_subscribe_repos.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/btcsuite/websocket"
@@ -64,9 +65,8 @@ func subscribeReposMsgType(evt *events.XRPCStreamEvent) (string, util.CBOR, bool
 	}
 }
 
-// writeEventFrame writes a single subscribeRepos frame — the CBOR event header
-// followed by the event body — to the relay connection, returning the message
-// type that was written (empty for error frames).
+// writeFrame writes one frame — the CBOR header followed by the body — to the
+// relay connection.
 //
 // btcsuite/websocket buffers each frame inside the connection and flushes it
 // only when the writer is closed. A writer abandoned without Close is flushed
@@ -74,6 +74,50 @@ func subscribeReposMsgType(evt *events.XRPCStreamEvent) (string, util.CBOR, bool
 // reach the relay and be read as a malformed event. Every error path here
 // returns before Close and leaves the buffer untouched; the caller tears the
 // connection down so nothing stale is ever written.
+func writeFrame(conn *websocket.Conn, header *events.EventHeader, obj util.CBOR) error {
+	// Bound the whole frame: NextWriter, the CBOR writes below and Close all
+	// flush through the same socket, and any of them can block on a stalled peer.
+	if err := conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout)); err != nil {
+		return fmt.Errorf("setting websocket write deadline: %w", err)
+	}
+
+	wc, err := conn.NextWriter(websocket.BinaryMessage)
+	if err != nil {
+		return fmt.Errorf("opening websocket writer: %w", err)
+	}
+
+	if err := header.MarshalCBOR(wc); err != nil {
+		return fmt.Errorf("writing event header: %w", err)
+	}
+	if err := obj.MarshalCBOR(wc); err != nil {
+		return fmt.Errorf("writing event body: %w", err)
+	}
+	if err := wc.Close(); err != nil {
+		return fmt.Errorf("flushing event frame: %w", err)
+	}
+
+	return nil
+}
+
+// writeErrorFrame writes an error frame (op -1) naming a lexicon error, which
+// is how a stream reports that it will not serve the request at all.
+func writeErrorFrame(conn *websocket.Conn, name, message string) error {
+	header := events.EventHeader{Op: events.EvtKindErrorFrame}
+	return writeFrame(conn, &header, &events.ErrorFrame{Error: name, Message: message})
+}
+
+// writeInfoFrame writes an #info message frame. The stream continues normally
+// afterwards — this is a notice, not a refusal — which is why it is a message
+// frame rather than an error frame.
+func writeInfoFrame(conn *websocket.Conn, name, message string) error {
+	header := events.EventHeader{Op: events.EvtKindMessage, MsgType: "#info"}
+	body := &comatproto.SyncSubscribeRepos_Info{Name: name}
+	if message != "" {
+		body.Message = &message
+	}
+	return writeFrame(conn, &header, body)
+}
+
 func writeEventFrame(conn *websocket.Conn, header *events.EventHeader, evt *events.XRPCStreamEvent) (string, error) {
 	var obj util.CBOR
 
@@ -91,25 +135,8 @@ func writeEventFrame(conn *websocket.Conn, header *events.EventHeader, evt *even
 		obj = o
 	}
 
-	// Bound the whole frame: NextWriter, the CBOR writes below and Close all
-	// flush through the same socket, and any of them can block on a stalled peer.
-	if err := conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout)); err != nil {
-		return "", fmt.Errorf("setting websocket write deadline: %w", err)
-	}
-
-	wc, err := conn.NextWriter(websocket.BinaryMessage)
-	if err != nil {
-		return "", fmt.Errorf("opening websocket writer: %w", err)
-	}
-
-	if err := header.MarshalCBOR(wc); err != nil {
-		return "", fmt.Errorf("writing event header: %w", err)
-	}
-	if err := obj.MarshalCBOR(wc); err != nil {
-		return "", fmt.Errorf("writing event body: %w", err)
-	}
-	if err := wc.Close(); err != nil {
-		return "", fmt.Errorf("flushing event frame: %w", err)
+	if err := writeFrame(conn, header, obj); err != nil {
+		return "", err
 	}
 
 	return header.MsgType, nil
@@ -192,6 +219,79 @@ func (s *Server) handleSyncSubscribeRepos(e echo.Context) error {
 		} else {
 			since = &cursor
 			logger.Info("subscribing with cursor", "cursor", cursor)
+		}
+	}
+
+	// A cursor can name three different places, and the consumer has no way to
+	// tell them apart from the stream alone: inside the retained range, behind
+	// it, or ahead of it. Behind and ahead are both silent failures — the
+	// consumer waits forever on events that will never come — so each is
+	// reported in-band before the stream starts.
+	//
+	// This mirrors the reference PDS
+	// (packages/pds/src/api/com/atproto/sync/subscribeRepos.ts): a cursor past
+	// the newest seq is a FutureCursor error frame, and a cursor older than the
+	// retained window gets an #info frame naming OutdatedCursor — not an error
+	// frame, because the stream is still served from the earliest retained event
+	// rather than refused.
+	//
+	// The reference keys the outdated check off a wall-clock backfill limit. We
+	// ask the store directly for the range it retains: that is the same bound,
+	// without a second, drifting definition of it.
+	//
+	// One deliberate divergence: when the store holds nothing, we send no
+	// notice at all, where the reference reports any positive cursor as future.
+	// Cocoon's seq space is not the reference's — it is seeded from the wall
+	// clock and re-seeded whenever the table is empty (see NewDbPersister), so
+	// an empty store means "this host has not started sequencing", not "this
+	// cursor is nonsense". Reporting FutureCursor there would push every
+	// consumer to idle on a fresh deploy over a cursor that the very next event
+	// would have satisfied.
+	if since != nil && s.evtpersister != nil {
+		if oldest, newest, ok, err := s.evtpersister.EventSeqRange(ctx); err != nil {
+			logger.Error("unable to read retained event range", "err", err)
+		} else if ok {
+			switch {
+			case *since > newest:
+				// Nothing above this seq can ever arrive, so the consumer must be
+				// told to reset rather than left waiting on a range that is empty
+				// forever.
+				logger.Warn("cursor is ahead of the newest retained event",
+					"cursor", *since, "newest", newest)
+				if err := writeErrorFrame(conn, "FutureCursor",
+					"Cursor in the future."); err != nil {
+					logger.Error("error writing future cursor frame", "err", err)
+					return err
+				}
+				metrics.RelaySends.WithLabelValues(ident, "FutureCursor").Inc()
+				return nil
+			case *since+1 < oldest:
+				// The consumer asked for events we have already pruned. The
+				// precise question is whether its *next* event still exists: it
+				// has seen everything up to `since`, so it needs `since+1`
+				// onward, and if `since+1` is below our floor then the events in
+				// [since+1, oldest) are gone. A cursor at exactly oldest-1 is
+				// therefore not behind at all — it needs `oldest`, which we still
+				// hold — and warning there would be a false alarm that grows
+				// likelier as retention trims the bottom of the range.
+				//
+				// (The reference PDS warns when the next needed event is older
+				// than a wall-clock backfill limit, which fires while the event
+				// is still present. Keying off the retained floor instead warns
+				// only once the event is genuinely unservable.)
+				//
+				// Playback will serve from the oldest retained event, silently
+				// skipping the gap; the info frame is how the consumer learns
+				// that happened.
+				logger.Warn("cursor is older than the oldest retained event",
+					"cursor", *since, "oldest", oldest)
+				if err := writeInfoFrame(conn, "OutdatedCursor",
+					"Requested cursor exceeded limit. Possibly missing events"); err != nil {
+					logger.Error("error writing outdated cursor frame", "err", err)
+					return err
+				}
+				metrics.RelaySends.WithLabelValues(ident, "OutdatedCursor").Inc()
+			}
 		}
 	}
 

--- a/server/persist.go
+++ b/server/persist.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
 	"sync"
 	"time"
@@ -154,6 +155,33 @@ func (p *DbPersister) Playback(ctx context.Context, since int64, cb func(*events
 			return nil
 		}
 	}
+}
+
+// EventSeqRange reports the oldest and newest seq this host still retains.
+//
+// The pair describes the only range that can be served: pruning removes whole
+// seqs from the bottom, so a cursor below the oldest retained seq names events
+// that no longer exist. ok is false when the store holds no events at all,
+// which is not the same as an empty range.
+func (p *DbPersister) EventSeqRange(ctx context.Context) (oldest, newest int64, ok bool, err error) {
+	var row struct {
+		Oldest sql.NullInt64
+		Newest sql.NullInt64
+	}
+
+	// MIN/MAX over an empty table yields NULL, hence the nullable scan.
+	if err := p.Db.WithContext(ctx).
+		Model(&models.EventRecord{}).
+		Select("MIN(seq) AS oldest, MAX(seq) AS newest").
+		Scan(&row).Error; err != nil {
+		return 0, 0, false, fmt.Errorf("querying retained event seq range: %w", err)
+	}
+
+	if !row.Oldest.Valid || !row.Newest.Valid {
+		return 0, 0, false, nil
+	}
+
+	return row.Oldest.Int64, row.Newest.Int64, true, nil
 }
 
 func (p *DbPersister) TakeDownRepo(ctx context.Context, uid indigomodels.Uid) error {

--- a/server/server.go
+++ b/server/server.go
@@ -82,6 +82,7 @@ type Server struct {
 	repoman       *RepoMan
 	oauthProvider *provider.Provider
 	evtman        *events.EventManager
+	evtpersister  *DbPersister
 	passport      *identity.Passport
 	scopeResolver scopes.PermissionSetResolver
 	fallbackProxy string
@@ -449,6 +450,7 @@ func New(args *Args) (*Server, error) {
 			FallbackProxy:     args.FallbackProxy,
 		},
 		evtman:        events.NewEventManager(evtPersister),
+		evtpersister:  evtPersister,
 		passport:      identity.NewPassport(h, identity.NewMemCache(10_000)),
 		scopeResolver: scopes.NewIndigoResolver(),
 

--- a/server/subscribe_repos_test.go
+++ b/server/subscribe_repos_test.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"runtime"
@@ -67,14 +70,19 @@ func counterTotal(t *testing.T, name string) float64 {
 func newSubscribeTestServer(t *testing.T) *Server {
 	t.Helper()
 	s := newTestServer(t)
-	s.evtman = newTestEvtman(t)
+	evtman, persister := newTestEvtmanPersister(t)
+	s.evtman = evtman
+	// The handler consults the persister for the retained seq range, so tests
+	// must wire the same instance the event manager writes through.
+	s.evtpersister = persister
 	s.repoman = NewRepoMan(s)
 	return s
 }
 
-// serveSubscribeRepos stands up a real HTTP server hosting the handler and
-// returns a dialer for it.
-func serveSubscribeRepos(t *testing.T, s *Server) func(ua string) *websocket.Conn {
+// startSubscribeReposServer stands up a real HTTP server hosting the handler and
+// returns the websocket URL. Tests that need query parameters (a cursor) dial
+// the returned URL directly.
+func startSubscribeReposServer(t *testing.T, s *Server) string {
 	t.Helper()
 
 	e := echo.New()
@@ -88,7 +96,15 @@ func serveSubscribeRepos(t *testing.T, s *Server) func(ua string) *websocket.Con
 	go func() { _ = srv.Serve(ln) }()
 	t.Cleanup(func() { _ = srv.Close() })
 
-	url := "ws://" + ln.Addr().String() + "/xrpc/com.atproto.sync.subscribeRepos"
+	return "ws://" + ln.Addr().String() + "/xrpc/com.atproto.sync.subscribeRepos"
+}
+
+// serveSubscribeRepos stands up a real HTTP server hosting the handler and
+// returns a dialer for it.
+func serveSubscribeRepos(t *testing.T, s *Server) func(ua string) *websocket.Conn {
+	t.Helper()
+
+	url := startSubscribeReposServer(t, s)
 	return func(ua string) *websocket.Conn {
 		t.Helper()
 		hdr := http.Header{}
@@ -99,6 +115,71 @@ func serveSubscribeRepos(t *testing.T, s *Server) func(ua string) *websocket.Con
 		}
 		return c
 	}
+}
+
+// dialSubscribeRepos connects to the handler, optionally naming a cursor.
+func dialSubscribeRepos(t *testing.T, url string, cursor *int64) *websocket.Conn {
+	t.Helper()
+	if cursor != nil {
+		url = fmt.Sprintf("%s?cursor=%d", url, *cursor)
+	}
+	hdr := http.Header{}
+	hdr.Set("User-Agent", "relay/cursor-test")
+	c, _, err := websocket.DefaultDialer.Dial(url, hdr)
+	if err != nil {
+		t.Fatalf("dial %s: %v", url, err)
+	}
+	return c
+}
+
+// wsFrame is one decoded websocket frame: the CBOR event header plus the
+// undecoded body bytes.
+type wsFrame struct {
+	header events.EventHeader
+	body   []byte
+}
+
+// readWSFrame reads one frame and splits it into header and body.
+func readWSFrame(t *testing.T, c *websocket.Conn) wsFrame {
+	t.Helper()
+
+	if err := c.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	_, data, err := c.ReadMessage()
+	if err != nil {
+		t.Fatalf("read message: %v", err)
+	}
+
+	r := bytes.NewReader(data)
+	var header events.EventHeader
+	if err := header.UnmarshalCBOR(r); err != nil {
+		t.Fatalf("decode event header: %v", err)
+	}
+	body, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read frame body: %v", err)
+	}
+
+	return wsFrame{header: header, body: body}
+}
+
+func (f wsFrame) decodeError(t *testing.T) events.ErrorFrame {
+	t.Helper()
+	var ef events.ErrorFrame
+	if err := ef.UnmarshalCBOR(bytes.NewReader(f.body)); err != nil {
+		t.Fatalf("decode error frame: %v", err)
+	}
+	return ef
+}
+
+func (f wsFrame) decodeInfo(t *testing.T) comatproto.SyncSubscribeRepos_Info {
+	t.Helper()
+	var info comatproto.SyncSubscribeRepos_Info
+	if err := info.UnmarshalCBOR(bytes.NewReader(f.body)); err != nil {
+		t.Fatalf("decode info frame: %v", err)
+	}
+	return info
 }
 
 func emitAccountEvent(s *Server) {
@@ -454,6 +535,261 @@ func TestSubscribeReposDetectsSilentPeer(t *testing.T) {
 
 	if got := gaugeRelaysConnected(t); got != 0 {
 		t.Errorf("cocoon_relays_connected = %v, want 0 after a silent peer was reaped", got)
+	}
+}
+
+// seedEvents writes n events through the persister and returns their seqs.
+func seedEvents(t *testing.T, s *Server, n int) (oldest, newest int64) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		emitAccountEvent(s)
+	}
+	o, nn, ok, err := s.evtpersister.EventSeqRange(context.Background())
+	if err != nil {
+		t.Fatalf("event seq range: %v", err)
+	}
+	if !ok {
+		t.Fatal("no events retained after seeding")
+	}
+	return o, nn
+}
+
+// TestSubscribeReposSignalsOutdatedCursor asserts a cursor behind the retained
+// window is reported with an #info frame naming OutdatedCursor, before any
+// event is served.
+//
+// Without it, playback silently starts at the oldest retained event: the
+// consumer is never told that the events it asked for were pruned, so a gap in
+// its view of the repo is indistinguishable from "nothing happened". The
+// reference PDS emits exactly this frame for exactly this case.
+func TestSubscribeReposSignalsOutdatedCursor(t *testing.T) {
+	s := newSubscribeTestServer(t)
+	oldest, _ := seedEvents(t, s, 5)
+
+	url := startSubscribeReposServer(t, s)
+	stale := oldest - 100
+	c := dialSubscribeRepos(t, url, &stale)
+	defer c.Close()
+
+	f := readWSFrame(t, c)
+	if f.header.Op != events.EvtKindMessage || f.header.MsgType != "#info" {
+		t.Fatalf("frame = {op:%d t:%q}, want an #info message frame", f.header.Op, f.header.MsgType)
+	}
+	info := f.decodeInfo(t)
+	if info.Name != "OutdatedCursor" {
+		t.Errorf("#info name = %q, want OutdatedCursor", info.Name)
+	}
+	// The lexicon makes the message optional, but the reference sends one and a
+	// consumer logs it verbatim, so a silent notice would be a regression in the
+	// operator's ability to tell why their cursor was rejected.
+	if info.Message == nil || *info.Message == "" {
+		t.Error("#info frame carries no message")
+	}
+}
+
+// TestSubscribeReposDoesNotSignalOutdatedCursorWithinWindow asserts the notice
+// is not sent to a consumer whose next event is still retained. A false
+// OutdatedCursor tells a consumer it lost events when it did not.
+//
+// The boundary is the interesting part: a cursor of oldest-1 needs oldest,
+// which we still hold, so it is fully served and must stay quiet.
+func TestSubscribeReposDoesNotSignalOutdatedCursorWithinWindow(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		offset   int64 // added to oldest to form the cursor
+		wantInfo bool
+	}{
+		{"exactly_at_oldest", 0, false},
+		{"one_below_oldest_still_served", -1, false},
+		{"two_below_oldest_first_gap", -2, true},
+		{"far_below_oldest", -50, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newSubscribeTestServer(t)
+			oldest, _ := seedEvents(t, s, 5)
+
+			url := startSubscribeReposServer(t, s)
+			cursor := oldest + tc.offset
+			c := dialSubscribeRepos(t, url, &cursor)
+			defer c.Close()
+
+			// The stream is live regardless: the sentinel, when present, is the
+			// first frame. Give the handler a moment to write it if it will.
+			gotInfo := false
+			for i := 0; i < 5; i++ {
+				emitAccountEvent(s)
+				if err := c.SetReadDeadline(time.Now().Add(300 * time.Millisecond)); err != nil {
+					t.Fatalf("set deadline: %v", err)
+				}
+				_, data, err := c.ReadMessage()
+				if err != nil {
+					break
+				}
+				// Don't consume the stream further; a single frame is enough to
+				// tell whether a sentinel was emitted first.
+				r := bytes.NewReader(data)
+				var header events.EventHeader
+				if err := header.UnmarshalCBOR(r); err != nil {
+					t.Fatalf("decode header: %v", err)
+				}
+				if header.Op == events.EvtKindMessage && header.MsgType == "#info" {
+					gotInfo = true
+				}
+				break
+			}
+
+			if gotInfo != tc.wantInfo {
+				t.Errorf("cursor=%d (oldest=%d): OutdatedCursor sent = %v, want %v",
+					cursor, oldest, gotInfo, tc.wantInfo)
+			}
+		})
+	}
+}
+
+// TestSubscribeReposSignalsFutureCursor asserts a cursor ahead of every event we
+// have is refused with a FutureCursor error frame, and that the connection is
+// then closed rather than left open on a stream that can never produce an event
+// above that seq.
+//
+// This is the case that silently hangs a consumer: nothing above the cursor can
+// ever be sent, so without a refusal the consumer waits forever. The relay
+// treats FutureCursor as "drop the connection and reset this host to idle",
+// which is the recovery path. (cmd/relay/relay/slurper.go)
+func TestSubscribeReposSignalsFutureCursor(t *testing.T) {
+	s := newSubscribeTestServer(t)
+	_, newest := seedEvents(t, s, 3)
+
+	url := startSubscribeReposServer(t, s)
+	ahead := newest + 1_000_000
+	c := dialSubscribeRepos(t, url, &ahead)
+	defer c.Close()
+
+	f := readWSFrame(t, c)
+	if f.header.Op != events.EvtKindErrorFrame {
+		t.Fatalf("frame op = %d, want %d (error frame)", f.header.Op, events.EvtKindErrorFrame)
+	}
+	ef := f.decodeError(t)
+	if ef.Error != "FutureCursor" {
+		t.Errorf("error frame name = %q, want FutureCursor", ef.Error)
+	}
+
+	// The handler must not keep the stream open: there is nothing it could ever
+	// send. The close frame proves the teardown is deliberate.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if err := c.SetReadDeadline(deadline); err != nil {
+			t.Fatalf("set deadline: %v", err)
+		}
+		_, _, err := c.ReadMessage()
+		if err != nil {
+			if !websocket.IsCloseError(err, websocket.CloseGoingAway) &&
+				!websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+				t.Fatalf("stream ended without a deliberate close: %v", err)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("future cursor: handler left the connection open")
+		}
+	}
+}
+
+// TestSubscribeReposCursorAtNewestIsServed asserts the ordinary caught-up case
+// stays silent. The relay sits here most of the time — its cursor equals the
+// newest seq — so warning on it would spam every healthy reconnect.
+func TestSubscribeReposCursorAtNewestIsServed(t *testing.T) {
+	s := newSubscribeTestServer(t)
+	_, newest := seedEvents(t, s, 4)
+
+	url := startSubscribeReposServer(t, s)
+	c := dialSubscribeRepos(t, url, &newest)
+	defer c.Close()
+
+	// Push a fresh event; the consumer must receive stream content, not a
+	// cursor notice.
+	emitAccountEvent(s)
+
+	f := readWSFrame(t, c)
+	if f.header.Op == events.EvtKindErrorFrame {
+		t.Fatalf("caught-up consumer was refused: %+v", f.decodeError(t))
+	}
+	if f.header.Op == events.EvtKindMessage && f.header.MsgType == "#info" {
+		if info := f.decodeInfo(t); info.Name == "OutdatedCursor" {
+			t.Fatal("caught-up consumer was sent OutdatedCursor; its next event was retained")
+		}
+	}
+}
+
+// TestSubscribeReposNoCursorIsSilent asserts a fresh consumer with no cursor
+// gets no notice: it is asking for "from now on", and it has lost nothing.
+func TestSubscribeReposNoCursorIsSilent(t *testing.T) {
+	s := newSubscribeTestServer(t)
+	seedEvents(t, s, 3)
+
+	url := startSubscribeReposServer(t, s)
+	c := dialSubscribeRepos(t, url, nil)
+	defer c.Close()
+
+	emitAccountEvent(s)
+
+	f := readWSFrame(t, c)
+	if f.header.Op == events.EvtKindErrorFrame {
+		t.Fatalf("cursorless consumer was refused: %+v", f.decodeError(t))
+	}
+	if f.header.Op == events.EvtKindMessage && f.header.MsgType == "#info" {
+		if info := f.decodeInfo(t); info.Name == "OutdatedCursor" {
+			t.Fatal("cursorless consumer was sent OutdatedCursor; it has no cursor to be behind")
+		}
+	}
+}
+
+// TestSubscribeReposEmptyStoreServesNoCursorNotice asserts a host with no
+// retained events does not claim the cursor is outdated. On a fresh store every
+// cursor is "ahead" of nothing, and reporting a failure the consumer cannot act
+// on would make an empty PDS look broken.
+func TestSubscribeReposEmptyStoreServesNoCursorNotice(t *testing.T) {
+	s := newSubscribeTestServer(t)
+
+	url := startSubscribeReposServer(t, s)
+	cursor := int64(1)
+	c := dialSubscribeRepos(t, url, &cursor)
+	defer c.Close()
+
+	emitAccountEvent(s)
+
+	f := readWSFrame(t, c)
+	if f.header.Op == events.EvtKindErrorFrame {
+		t.Fatalf("first-ever consumer was refused on an empty store: %+v", f.decodeError(t))
+	}
+}
+
+// TestEventSeqRangeReportsRetainedBounds covers the query directly: an empty
+// store reports ok=false, and a populated one reports the true floor and
+// ceiling so the handler's comparison is against real retained bounds.
+func TestEventSeqRangeReportsRetainedBounds(t *testing.T) {
+	s := newSubscribeTestServer(t)
+	ctx := context.Background()
+
+	if _, _, ok, err := s.evtpersister.EventSeqRange(ctx); err != nil {
+		t.Fatalf("empty store: %v", err)
+	} else if ok {
+		t.Fatal("empty store reported a retained range")
+	}
+
+	oldest, newest := seedEvents(t, s, 3)
+	if oldest >= newest {
+		t.Fatalf("range = [%d,%d], want oldest < newest", oldest, newest)
+	}
+
+	gotOldest, gotNewest, ok, err := s.evtpersister.EventSeqRange(ctx)
+	if err != nil {
+		t.Fatalf("populated store: %v", err)
+	}
+	if !ok {
+		t.Fatal("populated store reported no retained range")
+	}
+	if gotOldest != oldest || gotNewest != newest {
+		t.Errorf("range = [%d,%d], want [%d,%d]", gotOldest, gotNewest, oldest, newest)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Report out-of-range cursors on `com.atproto.sync.subscribeRepos` instead of staying silent about a range the host cannot serve.
- A cursor **ahead** of every retained event gets a `FutureCursor` error frame and the stream closes; a cursor **behind** the retained floor gets an `#info` frame naming `OutdatedCursor` and the stream continues.
- Mirrors the reference PDS, which implements both cases (`packages/pds/src/api/com/atproto/sync/subscribeRepos.ts:29-38`). `FutureCursor` and `OutdatedCursor` exist in indigo's copy of the lexicon too, but indigo's Go `EventManager` emits neither — its `Subscribe` carries a `// TODO: send an error frame or something?` (indigo `events/events.go:390`).

## Changes
- `server/persist.go`: add `DbPersister.EventSeqRange`, returning the oldest and newest retained seq (`ok=false` on an empty store). `MIN`/`MAX` yield `NULL` on an empty table, hence the nullable scan.
- `server/server.go`: hold the persister on `Server` as `evtpersister` so the handler can consult the same instance the event manager writes through.
- `server/handle_sync_subscribe_repos.go`:
  - Split the frame writer into `writeFrame` and reuse it for two new wrappers, so the existing write-deadline discipline covers the new paths:
    - `writeErrorFrame` — op `-1`, used for `FutureCursor`.
    - `writeInfoFrame` — an `#info` **message** frame, used for `OutdatedCursor`. This is deliberate: the reference sends it as a message frame because the stream is still served from the oldest retained event rather than refused.
  - `FutureCursor` is written, then the handler returns, so the deferred close frame fires. Nothing above that seq can ever arrive, so leaving the connection open would hang the consumer; the relay treats `FutureCursor` as "drop the connection and reset the host to idle" (`cmd/relay/relay/slurper.go:441`), which is the recovery path.
  - The outdated comparison is `*since+1 < oldest`, keyed off the store's real retained floor rather than a re-derived wall-clock backfill limit. Playback uses an exclusive cursor (`seq > since`), so a cursor of `oldest-1` still has its next event and must stay quiet; `since+1 < oldest` is exactly "the next needed event is gone".
  - An empty store sends nothing. Cocoon's seq space is seeded from the wall clock and re-seeded whenever the table is empty (`NewDbPersister`), so "no events" means "not sequencing yet" rather than "your cursor is nonsense" — reporting `FutureCursor` there would push every consumer to idle on a fresh deploy.

## Validation
- `go test -race ./...` — pass (all packages).
- `go vet ./...`, `gofmt -l server/` — clean.
- New tests, all confirmed to **fail against the unpatched handler** (stripped the implementation and re-ran):
  - `TestSubscribeReposSignalsOutdatedCursor` — `#info` frame named `OutdatedCursor` with a message, arrived before any event.
  - `TestSubscribeReposDoesNotSignalOutdatedCursorWithinWindow` — table-driven over the boundary: `oldest`, `oldest-1` stay silent; `oldest-2` and far-below warn.
  - `TestSubscribeReposSignalsFutureCursor` — error frame named `FutureCursor`, followed by a deliberate close. Without the fix this failed as an **i/o timeout**, i.e. the silent hang being fixed.
  - `TestSubscribeReposCursorAtNewestIsServed` / `TestSubscribeReposNoCursorIsSilent` / `TestSubscribeReposEmptyStoreServesNoCursorNotice` — the no-false-positive cases. The relay's cursor normally equals the newest seq, so warning there would fire on every healthy reconnect.
  - `TestEventSeqRangeReportsRetainedBounds` — the query, including `ok=false` on an empty store.
- `roast review` — report `20260911T081948Z-f87cb8f7`, `NO_FINDINGS`. One finding was raised and refuted by the verifier: it claimed `since+1 < oldest` was an off-by-one that should be `since < oldest`. The verifier killed it by citing `persist.go`'s exclusive-cursor semantics (`Where("seq > ?", cursor)`) — with `since == oldest-1` the next needed event is `oldest`, which is still retained, so warning there would be a false positive.

## Review notes
- **Measured context for why the silent case matters.** Against the live host, the relay's stored cursor was `1770283459` and cocoon's retained range was `1770282690…1770283459` (770 events over 72h). The relay was *caught up*, not wedged — its cursor equalled the newest seq — so it was receiving zero events simply because there were none. The `1006 unexpected EOF` in the logs was the idle-reap fixed by #149, not this bug. This change is therefore a correctness fix for the out-of-range cases, not the explanation for that log spam.
- **Behaviour change on the wire**, affecting every consumer (relay, TAP, mirrors), hence the separate PR. In-range cursors are untouched: the guard only runs when `cursor` is present and only fires outside the retained window.
- **Deliberate divergence from the reference on empty stores**, documented inline. The reference reports any positive cursor as future when the sequencer has no rows; cocoon re-seeds its seq space from the wall clock on an empty table, so the same test would be wrong here.
- **Not covered:** `ConsumerTooSlow` is still emitted by indigo's event manager on the existing slow-consumer path and is unchanged by this PR. The `#info` frame is validated by decode round-trip in tests; I have not yet watched a live relay react to a real `FutureCursor` (that needs a merged deploy).
- Not enrolled the roast git gate in this repo — that's opt-in and I didn't want to install a hook unasked.
