### PR TITLE
Validate repository imports and commit snapshots atomically

### DIFF
--- a/server/handle_import_repo.go
+++ b/server/handle_import_repo.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -54,6 +55,8 @@ func (s *Server) handleRepoImportRepo(e echo.Context) error {
 		return helpers.InputError(e, nil)
 	}
 
+	unlock := s.lockRepoWrite(urepo.Repo.Did)
+	defer unlock()
 	conflict := errors.New("repository changed during import")
 	err = s.db.Transaction(ctx, func(tx *db.DB) error {
 		bs := sqlite_blockstore.New(urepo.Repo.Did, tx)
@@ -99,6 +102,17 @@ func (s *Server) handleRepoImportRepo(e echo.Context) error {
 
 // Validate against the CAR alone, not blocks left over from an earlier repo.
 func readRepoImport(ctx context.Context, body []byte, did string) (*atp.Repo, []blocks.Block, []models.Record, error) {
+	// go-car can return EOF for truncated or empty sections as well as clean EOF.
+	for remaining := body; len(remaining) > 0; {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, nil, err
+		}
+		size, n := binary.Uvarint(remaining)
+		if n <= 0 || size == 0 || size > uint64(len(remaining)-n) {
+			return nil, nil, nil, fmt.Errorf("invalid CAR section length")
+		}
+		remaining = remaining[n+int(size):]
+	}
 	cs, err := car.NewCarReader(bytes.NewReader(body))
 	if err != nil {
 		return nil, nil, nil, err
@@ -150,10 +164,15 @@ func readRepoImport(ctx context.Context, body []byte, did string) (*atp.Repo, []
 	}
 	var records []models.Record
 	clock := syntax.NewTIDClock(0)
+	var previous string
 	err = r.MST.Walk(func(key []byte, c cid.Cid) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		if string(key) <= previous {
+			return fmt.Errorf("repository keys are not strictly ordered")
+		}
+		previous = string(key)
 		nsid, rkey, ok := strings.Cut(string(key), "/")
 		if !ok {
 			return fmt.Errorf("invalid record path")

--- a/server/handle_import_repo.go
+++ b/server/handle_import_repo.go
@@ -4,14 +4,18 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"strings"
 
+	"github.com/bluesky-social/indigo/atproto/atdata"
+	atp "github.com/bluesky-social/indigo/atproto/repo"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/haileyok/cocoon/internal/db"
 	"github.com/haileyok/cocoon/internal/helpers"
 	"github.com/haileyok/cocoon/models"
+	"github.com/haileyok/cocoon/sqlite_blockstore"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-car"
@@ -44,90 +48,137 @@ func (s *Server) handleRepoImportRepo(e echo.Context) error {
 		return helpers.ServerError(e, nil)
 	}
 
-	bs := s.getBlockstore(urepo.Repo.Did)
-
-	cs, err := car.NewCarReader(bytes.NewReader(b))
+	r, importedBlocks, records, err := readRepoImport(ctx, b, urepo.Repo.Did)
 	if err != nil {
-		logger.Error("could not read car in import request", "error", err)
-		return helpers.ServerError(e, nil)
+		logger.Error("invalid repository import", "error", err)
+		return helpers.InputError(e, nil)
 	}
 
-	orderedBlocks := []blocks.Block{}
-	currBlock, err := cs.Next()
-	if err != nil {
-		logger.Error("could not get first block from car", "error", err)
-		return helpers.ServerError(e, nil)
-	}
-	currBlockCt := 1
-
-	for currBlock != nil {
-		logger.Info("someone is importing their repo", "block", currBlockCt)
-		orderedBlocks = append(orderedBlocks, currBlock)
-		next, _ := cs.Next()
-		currBlock = next
-		currBlockCt++
-	}
-
-	slices.Reverse(orderedBlocks)
-
-	if err := bs.PutMany(context.TODO(), orderedBlocks); err != nil {
-		logger.Error("could not insert blocks", "error", err)
-		return helpers.ServerError(e, nil)
-	}
-
-	r, err := openRepo(context.TODO(), bs, cs.Header.Roots[0], urepo.Repo.Did)
-	if err != nil {
-		logger.Error("could not open repo", "error", err)
-		return helpers.ServerError(e, nil)
-	}
-
-	tx := s.db.Begin(ctx)
-
-	clock := syntax.NewTIDClock(0)
-
-	if err := r.MST.Walk(func(key []byte, cid cid.Cid) error {
-		pts := strings.Split(string(key), "/")
-		nsid := pts[0]
-		rkey := pts[1]
-		cidStr := cid.String()
-		b, err := bs.Get(context.TODO(), cid)
-		if err != nil {
-			logger.Error("record bytes don't exist in blockstore", "error", err)
-			return helpers.ServerError(e, nil)
-		}
-
-		rec := models.Record{
-			Did:       urepo.Repo.Did,
-			CreatedAt: clock.Next().String(),
-			Nsid:      nsid,
-			Rkey:      rkey,
-			Cid:       cidStr,
-			Value:     b.RawData(),
-		}
-
-		if err := tx.Save(rec).Error; err != nil {
+	conflict := errors.New("repository changed during import")
+	err = s.db.Transaction(ctx, func(tx *db.DB) error {
+		bs := sqlite_blockstore.New(urepo.Repo.Did, tx)
+		if err := tx.Exec(ctx, "DELETE FROM records WHERE did = ?", nil, urepo.Repo.Did).Error; err != nil {
 			return err
 		}
-
+		if err := tx.Exec(ctx, "DELETE FROM blocks WHERE did = ?", nil, urepo.Repo.Did).Error; err != nil {
+			return err
+		}
+		for _, block := range importedBlocks {
+			if err := bs.Put(ctx, block); err != nil {
+				return err
+			}
+		}
+		if len(records) > 0 {
+			if err := tx.Client().WithContext(ctx).CreateInBatches(&records, 100).Error; err != nil {
+				return err
+			}
+		}
+		// Preserve Cocoon's policy of re-signing with the destination key.
+		root, rev, err := commitRepo(ctx, bs, r, urepo.Repo.SigningKey)
+		if err != nil {
+			return err
+		}
+		result := tx.Exec(ctx, "UPDATE repos SET root = ?, rev = ? WHERE did = ? AND rev = ?", nil, root.Bytes(), rev, urepo.Repo.Did, urepo.Rev)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return conflict
+		}
 		return nil
-	}); err != nil {
-		tx.Rollback()
-		logger.Error("record bytes don't exist in blockstore", "error", err)
-		return helpers.ServerError(e, nil)
+	})
+	if errors.Is(err, conflict) {
+		return e.JSON(http.StatusConflict, map[string]string{"error": "InvalidSwap", "message": conflict.Error()})
 	}
-
-	tx.Commit()
-
-	root, rev, err := commitRepo(context.TODO(), bs, r, urepo.Repo.SigningKey)
 	if err != nil {
-		logger.Error("error committing", "error", err)
+		logger.Error("could not commit repository import", "error", err)
 		return helpers.ServerError(e, nil)
 	}
+	return e.NoContent(http.StatusOK)
+}
 
-	if err := s.UpdateRepo(context.TODO(), urepo.Repo.Did, root, rev); err != nil {
-		logger.Error("error updating repo after commit", "error", err)
-		return helpers.ServerError(e, nil)
+// Validate against the CAR alone, not blocks left over from an earlier repo.
+func readRepoImport(ctx context.Context, body []byte, did string) (*atp.Repo, []blocks.Block, []models.Record, error) {
+	cs, err := car.NewCarReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, nil, err
 	}
-
-	return nil
+	if len(cs.Header.Roots) != 1 {
+		return nil, nil, nil, fmt.Errorf("expected one CAR root")
+	}
+	bs := atp.NewTinyBlockstore()
+	var imported []blocks.Block
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, nil, err
+		}
+		block, err := cs.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if err := bs.Put(ctx, block); err != nil {
+			return nil, nil, nil, err
+		}
+		imported = append(imported, block)
+	}
+	root, err := bs.Get(ctx, cs.Header.Roots[0])
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	var commit atp.Commit
+	if err := commit.UnmarshalCBOR(bytes.NewReader(root.RawData())); err != nil {
+		return nil, nil, nil, err
+	}
+	if err := commit.VerifyStructure(); err != nil {
+		return nil, nil, nil, err
+	}
+	if commit.DID != did {
+		return nil, nil, nil, fmt.Errorf("commit DID does not match account")
+	}
+	r, err := openRepo(ctx, bs, cs.Header.Roots[0], did)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if r.MST.IsPartial() {
+		return nil, nil, nil, fmt.Errorf("incomplete repository tree")
+	}
+	if err := r.MST.Verify(); err != nil {
+		return nil, nil, nil, err
+	}
+	var records []models.Record
+	clock := syntax.NewTIDClock(0)
+	err = r.MST.Walk(func(key []byte, c cid.Cid) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		nsid, rkey, ok := strings.Cut(string(key), "/")
+		if !ok {
+			return fmt.Errorf("invalid record path")
+		}
+		if _, err := syntax.ParseNSID(nsid); err != nil {
+			return err
+		}
+		if _, err := syntax.ParseRecordKey(rkey); err != nil {
+			return err
+		}
+		block, err := bs.Get(ctx, c)
+		if err != nil {
+			return err
+		}
+		if _, err := atdata.UnmarshalCBOR(block.RawData()); err != nil {
+			return err
+		}
+		records = append(records, models.Record{
+			Did: did, CreatedAt: clock.Next().String(), Nsid: nsid, Rkey: rkey,
+			Cid: c.String(), Value: block.RawData(),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return r, imported, records, nil
 }

--- a/server/import_integrity_test.go
+++ b/server/import_integrity_test.go
@@ -1,0 +1,367 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/atcrypto"
+	atp "github.com/bluesky-social/indigo/atproto/repo"
+	"github.com/bluesky-social/indigo/atproto/repo/mst"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/carstore"
+	"github.com/haileyok/cocoon/models"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/ipld/go-car"
+	"gorm.io/gorm"
+)
+
+func importFixture(t *testing.T, did string, paths []string) (cid.Cid, []blocks.Block, *atp.Repo) {
+	t.Helper()
+	ctx := context.Background()
+	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
+	r := &atp.Repo{DID: syntax.DID(did), Clock: syntax.NewTIDClock(0), MST: mst.NewEmptyTree(), RecordStore: bs}
+	for i, path := range paths {
+		rec := MarshalableMap{"$type": "app.bsky.feed.post", "text": fmt.Sprintf("imported record %d", i)}
+		c, err := putRecordBlock(ctx, bs, &rec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := r.MST.Insert([]byte(path), c); err != nil {
+			t.Fatal(err)
+		}
+	}
+	key, err := atcrypto.GeneratePrivateKeyK256()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, _, err := commitRepo(ctx, bs, r, key.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, err := bs.AllKeysChan(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var all []blocks.Block
+	for c := range keys {
+		c = cid.NewCidV1(cid.DagCBOR, c.Hash())
+		b, err := bs.Get(ctx, c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		all = append(all, b)
+	}
+	return root, all, r
+}
+
+func importCAR(t *testing.T, roots []cid.Cid, all []blocks.Block) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := car.WriteHeader(&car.CarHeader{Roots: roots, Version: 1}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range all {
+		if _, err := carstore.LdWrite(&buf, b.Cid().Bytes(), b.RawData()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return buf.Bytes()
+}
+
+func importState(t *testing.T, s *Server, did string) any {
+	t.Helper()
+	state := struct {
+		Repo    *models.RepoActor
+		Blocks  []models.Block
+		Records []models.Record
+	}{}
+	var err error
+	state.Repo, err = s.getRepoActorByDid(context.Background(), did)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.db.Client().Where("did = ?", did).Order("cid").Find(&state.Blocks).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := s.db.Client().Where("did = ?", did).Order("nsid, rkey").Find(&state.Records).Error; err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func TestImportRejectsIncompleteCAR(t *testing.T) {
+	for _, mode := range []string{"truncated", "bad-hash", "no-root", "multiple-roots", "missing-record", "partial-tree", "wrong-did", "invalid-path", "invalid-rev", "invalid-version"} {
+		t.Run(mode, func(t *testing.T) {
+			s := newTestServer(t)
+			account := s.createTestAccount(t, "import.pds.test")
+			s.seedGenesisRepo(t, account.Did, account.SigningKey)
+			before := importState(t, s, account.Did)
+			did := account.Did
+			if mode == "wrong-did" {
+				did = "did:web:someone-else.test"
+			}
+			paths := []string{"app.bsky.feed.post/one"}
+			if mode == "invalid-path" {
+				paths = []string{"no-slash"}
+			}
+			if mode == "partial-tree" {
+				for i := range 40 {
+					paths = append(paths, fmt.Sprintf("app.bsky.feed.post/item%d", i))
+				}
+			}
+			root, all, r := importFixture(t, did, paths)
+			if mode == "invalid-rev" || mode == "invalid-version" {
+				b, err := r.RecordStore.Get(context.Background(), root)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var commit atp.Commit
+				if err := commit.UnmarshalCBOR(bytes.NewReader(b.RawData())); err != nil {
+					t.Fatal(err)
+				}
+				if mode == "invalid-rev" {
+					commit.Rev = "invalid"
+				} else {
+					commit.Version = 2
+				}
+				var buf bytes.Buffer
+				if err := commit.MarshalCBOR(&buf); err != nil {
+					t.Fatal(err)
+				}
+				root, err = root.Prefix().Sum(buf.Bytes())
+				if err != nil {
+					t.Fatal(err)
+				}
+				block, err := blocks.NewBlockWithCid(buf.Bytes(), root)
+				if err != nil {
+					t.Fatal(err)
+				}
+				all = append(all, block)
+			}
+			roots := []cid.Cid{root}
+			if mode == "no-root" {
+				roots = nil
+			}
+			if mode == "multiple-roots" {
+				roots = append(roots, root)
+			}
+			if mode == "missing-record" || mode == "partial-tree" {
+				status, _ := callImportRepo(t, s, account, bytes.NewReader(importCAR(t, roots, all)))
+				if status != 200 {
+					t.Fatalf("complete fixture rejected: %d", status)
+				}
+				before = importState(t, s, account.Did)
+				nodes, leaves := map[cid.Cid]struct{}{}, map[cid.Cid]struct{}{}
+				collectTreeBlocks(r.MST.Root, nodes, leaves)
+				omit := leaves
+				if mode == "partial-tree" {
+					omit = nodes
+					delete(omit, *r.MST.Root.CID)
+					if len(omit) == 0 {
+						t.Fatal("fixture has no child nodes")
+					}
+				}
+				var kept []blocks.Block
+				for _, b := range all {
+					if _, drop := omit[b.Cid()]; !drop {
+						kept = append(kept, b)
+					}
+				}
+				all = kept
+			}
+			body := importCAR(t, roots, all)
+			if mode == "truncated" {
+				body = append(body, 0x80)
+			}
+			if mode == "bad-hash" {
+				body[len(body)-1] ^= 1
+			}
+			status, _ := callImportRepo(t, s, account, bytes.NewReader(body))
+			if status != 400 {
+				t.Fatalf("status = %d, want 400", status)
+			}
+			if !reflect.DeepEqual(before, importState(t, s, account.Did)) {
+				t.Fatal("invalid import changed persistent state")
+			}
+		})
+	}
+}
+
+func TestImportRollback(t *testing.T) {
+	for _, table := range []string{"blocks", "records", "repos", "commit"} {
+		t.Run(table, func(t *testing.T) {
+			s := newTestServer(t)
+			account := s.createTestAccount(t, "rollback-import.pds.test")
+			s.seedGenesisRepo(t, account.Did, account.SigningKey)
+			before := importState(t, s, account.Did)
+			operation := "INSERT"
+			if table == "repos" {
+				operation = "UPDATE"
+			}
+			if table == "commit" {
+				pool, err := s.db.Client().DB()
+				if err != nil {
+					t.Fatal(err)
+				}
+				pool.SetMaxOpenConns(1)
+				for _, query := range []string{
+					"PRAGMA foreign_keys = ON",
+					"CREATE TABLE import_parent (id INTEGER PRIMARY KEY)",
+					"CREATE TABLE import_guard (id INTEGER REFERENCES import_parent(id) DEFERRABLE INITIALLY DEFERRED)",
+					"CREATE TRIGGER fail_import AFTER INSERT ON records BEGIN INSERT INTO import_guard VALUES (1); END",
+				} {
+					if err := s.db.Exec(context.Background(), query, nil).Error; err != nil {
+						t.Fatal(err)
+					}
+				}
+			} else {
+				if err := s.db.Exec(context.Background(), "CREATE TRIGGER fail_import BEFORE "+operation+" ON "+table+" BEGIN SELECT RAISE(ABORT, 'test failure'); END", nil).Error; err != nil {
+					t.Fatal(err)
+				}
+			}
+			root, all, _ := importFixture(t, account.Did, []string{"app.bsky.feed.post/new"})
+			status, _ := callImportRepo(t, s, account, bytes.NewReader(importCAR(t, []cid.Cid{root}, all)))
+			if status != 500 {
+				t.Fatalf("status = %d, want 500", status)
+			}
+			if !reflect.DeepEqual(before, importState(t, s, account.Did)) {
+				t.Fatal("failed import left partial writes")
+			}
+		})
+	}
+}
+
+func TestImportReplacesRecords(t *testing.T) {
+	s := newTestServer(t)
+	account := s.createTestAccount(t, "replace-import.pds.test")
+	other := s.createTestAccount(t, "other-import.pds.test")
+	s.seedGenesisRepo(t, other.Did, other.SigningKey)
+	otherState := importState(t, s, other.Did)
+	for _, paths := range [][]string{{"app.bsky.feed.post/old", "app.bsky.feed.post/keep"}, {"app.bsky.feed.post/keep"}, {}} {
+		root, all, original := importFixture(t, account.Did, paths)
+		status, body := callImportRepo(t, s, account, bytes.NewReader(importCAR(t, []cid.Cid{root}, all)))
+		if status != 200 {
+			t.Fatalf("import: %d %s", status, body)
+		}
+		if !reflect.DeepEqual(otherState, importState(t, s, other.Did)) {
+			t.Fatal("import changed another account")
+		}
+		var records []models.Record
+		if err := s.db.Client().Where("did = ?", account.Did).Find(&records).Error; err != nil {
+			t.Fatal(err)
+		}
+		if len(records) != len(paths) {
+			t.Fatalf("got %d records, want %d", len(records), len(paths))
+		}
+		repo, err := s.getRepoActorByDid(context.Background(), account.Did)
+		if err != nil {
+			t.Fatal(err)
+		}
+		newRoot, err := cid.Cast(repo.Root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		loaded, err := openRepo(context.Background(), s.getBlockstore(account.Did), newRoot, account.Did)
+		if err != nil {
+			t.Fatal(err)
+		}
+		block, err := loaded.RecordStore.Get(context.Background(), newRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var commit atp.Commit
+		if err := commit.UnmarshalCBOR(bytes.NewReader(block.RawData())); err != nil {
+			t.Fatal(err)
+		}
+		key, err := atcrypto.ParsePrivateBytesK256(account.SigningKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pub, err := key.PublicKey()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := commit.VerifySignature(pub); err != nil {
+			t.Fatal(err)
+		}
+		if commit.Rev != repo.Rev || commit.DID != account.Did {
+			t.Fatal("commit metadata differs from account")
+		}
+		expectedData, err := original.MST.RootCID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if expectedData == nil || commit.Data != *expectedData {
+			t.Fatal("import changed the source tree")
+		}
+		for _, record := range records {
+			c, err := loaded.MST.Get([]byte(record.Nsid + "/" + record.Rkey))
+			if err != nil || c == nil || c.String() != record.Cid {
+				t.Fatal("record index differs from committed tree")
+			}
+			block, err := loaded.RecordStore.Get(context.Background(), *c)
+			if err != nil || !bytes.Equal(block.RawData(), record.Value) {
+				t.Fatal("record bytes differ from blockstore")
+			}
+		}
+	}
+}
+
+func TestImportStaleHeadAndCancellation(t *testing.T) {
+	for _, mode := range []string{"stale-head", "cancel-before", "cancel-during"} {
+		t.Run(mode, func(t *testing.T) {
+			s := newTestServer(t)
+			account := s.createTestAccount(t, "interrupted-import.pds.test")
+			s.seedGenesisRepo(t, account.Did, account.SigningKey)
+			repo, err := s.getRepoActorByDid(context.Background(), account.Did)
+			if err != nil {
+				t.Fatal(err)
+			}
+			root, all, _ := importFixture(t, account.Did, []string{"app.bsky.feed.post/new"})
+			body := importCAR(t, []cid.Cid{root}, all)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			want := 400
+			switch mode {
+			case "stale-head":
+				status, _ := callImportRepo(t, s, account, bytes.NewReader(body))
+				if status != 200 {
+					t.Fatalf("first import: %d", status)
+				}
+				want = 409
+			case "cancel-before":
+				cancel()
+			case "cancel-during":
+				if err := s.db.Client().Callback().Create().After("gorm:create").Register("cancel-import", func(tx *gorm.DB) {
+					if tx.Statement.Table == "records" {
+						cancel()
+					}
+				}); err != nil {
+					t.Fatal(err)
+				}
+				want = 500
+			}
+			before := importState(t, s, account.Did)
+			c, w := newRequestContext("POST", "/xrpc/com.atproto.repo.importRepo", "", nil)
+			c.Request().Body = io.NopCloser(bytes.NewReader(body))
+			c.SetRequest(c.Request().WithContext(ctx))
+			c.Set("repo", repo)
+			if err := s.handleRepoImportRepo(c); err != nil {
+				t.Fatal(err)
+			}
+			if w.Code != want {
+				t.Fatalf("status = %d, want %d", w.Code, want)
+			}
+			if !reflect.DeepEqual(before, importState(t, s, account.Did)) {
+				t.Fatal("interrupted import changed state")
+			}
+		})
+	}
+}

--- a/server/import_integrity_test.go
+++ b/server/import_integrity_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/bluesky-social/indigo/atproto/atcrypto"
 	atp "github.com/bluesky-social/indigo/atproto/repo"
@@ -97,7 +99,7 @@ func importState(t *testing.T, s *Server, did string) any {
 }
 
 func TestImportRejectsIncompleteCAR(t *testing.T) {
-	for _, mode := range []string{"truncated", "bad-hash", "no-root", "multiple-roots", "missing-record", "partial-tree", "wrong-did", "invalid-path", "invalid-rev", "invalid-version"} {
+	for _, mode := range []string{"truncated", "missing-section", "empty-section", "bad-hash", "no-root", "multiple-roots", "missing-record", "partial-tree", "wrong-did", "invalid-path", "invalid-rev", "invalid-version"} {
 		t.Run(mode, func(t *testing.T) {
 			s := newTestServer(t)
 			account := s.createTestAccount(t, "import.pds.test")
@@ -179,6 +181,12 @@ func TestImportRejectsIncompleteCAR(t *testing.T) {
 			body := importCAR(t, roots, all)
 			if mode == "truncated" {
 				body = append(body, 0x80)
+			}
+			if mode == "missing-section" {
+				body = append(body, 0x01)
+			}
+			if mode == "empty-section" {
+				body = append(body, 0x00, 0xff)
 			}
 			if mode == "bad-hash" {
 				body[len(body)-1] ^= 1
@@ -363,5 +371,166 @@ func TestImportStaleHeadAndCancellation(t *testing.T) {
 				t.Fatal("interrupted import changed state")
 			}
 		})
+	}
+}
+
+func TestImportRejectsMisorderedTree(t *testing.T) {
+	s := newTestServer(t)
+	account := s.createTestAccount(t, "misordered.pds.test")
+	s.seedGenesisRepo(t, account.Did, account.SigningKey)
+	before := importState(t, s, account.Did)
+	var a, b string
+	for i := 0; b == ""; i++ {
+		path := fmt.Sprintf("app.bsky.feed.post/%06d", i)
+		if a == "" && mst.HeightForKey([]byte(path)) == 1 {
+			a = path
+		} else if a != "" && mst.HeightForKey([]byte(path)) == 0 {
+			b = path
+		}
+	}
+	root, all, r := importFixture(t, account.Did, []string{a, b})
+	value, err := r.MST.Get([]byte(a))
+	if err != nil || value == nil {
+		t.Fatal("missing fixture record", err)
+	}
+	addNode := func(node mst.NodeData) cid.Cid {
+		t.Helper()
+		raw, c, err := node.Bytes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		block, err := blocks.NewBlockWithCid(raw, *c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		all = append(all, block)
+		return *c
+	}
+	left := addNode(mst.NodeData{Entries: []mst.EntryData{{KeySuffix: []byte(b), Value: *value}}})
+	data := addNode(mst.NodeData{Left: &left, Entries: []mst.EntryData{{KeySuffix: []byte(a), Value: *value}}})
+	block, err := r.RecordStore.Get(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var commit atp.Commit
+	if err := commit.UnmarshalCBOR(bytes.NewReader(block.RawData())); err != nil {
+		t.Fatal(err)
+	}
+	commit.Data = data
+	var buf bytes.Buffer
+	if err := commit.MarshalCBOR(&buf); err != nil {
+		t.Fatal(err)
+	}
+	root, err = root.Prefix().Sum(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err = blocks.NewBlockWithCid(buf.Bytes(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	all = append(all, block)
+	status, _ := callImportRepo(t, s, account, bytes.NewReader(importCAR(t, []cid.Cid{root}, all)))
+	if status != 400 {
+		t.Fatalf("status = %d, want 400", status)
+	}
+	if !reflect.DeepEqual(before, importState(t, s, account.Did)) {
+		t.Fatal("misordered tree changed persistent state")
+	}
+}
+
+func TestImportSerializesWithWrites(t *testing.T) {
+	s := newTestServer(t)
+	s.repoman = NewRepoMan(s)
+	s.evtman = newTestEvtman(t)
+	account := s.createTestAccount(t, "overlap.pds.test")
+	s.seedGenesisRepo(t, account.Did, account.SigningKey)
+	repo, err := s.getRepoActorByDid(context.Background(), account.Did)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, all, _ := importFixture(t, account.Did, []string{"app.bsky.feed.post/imported"})
+	c, response := newRequestContext("POST", "/xrpc/com.atproto.repo.importRepo", "", nil)
+	c.Request().Body = io.NopCloser(bytes.NewReader(importCAR(t, []cid.Cid{root}, all)))
+	c.Set("repo", repo)
+	paused, resume := make(chan struct{}), make(chan struct{})
+	if err := s.db.Client().Callback().Raw().Before("gorm:raw").Register("pause-head", func(tx *gorm.DB) {
+		if tx.Statement.SQL.String() == "UPDATE repos SET root = ?, rev = ? WHERE did = ?" {
+			close(paused)
+			<-resume
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := s.repoman.applyWrites(context.Background(), repo.Repo, []Op{{Type: OpTypeCreate, Collection: "app.bsky.feed.post", Rkey: strPtr("written"), Record: rmPostRecord("written")}}, nil)
+		writeDone <- err
+	}()
+	select {
+	case <-paused:
+	case err := <-writeDone:
+		t.Fatalf("write did not reach head update: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("write did not reach head update")
+	}
+	importDone := make(chan error, 1)
+	go func() { importDone <- s.handleRepoImportRepo(c) }()
+	select {
+	case err := <-importDone:
+		close(resume)
+		<-writeDone
+		t.Fatalf("import completed during unpublished write: status %d, error %v", response.Code, err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(resume)
+	if err := <-writeDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-importDone; err != nil {
+		t.Fatal(err)
+	}
+	if response.Code != 409 {
+		t.Fatalf("stale import status = %d, want 409", response.Code)
+	}
+	if leaves := walkMstLeaves(t, s, account.Did); len(leaves) != 1 || !leaves["app.bsky.feed.post/written"].Defined() {
+		t.Fatalf("lost completed write: %v", leaves)
+	}
+}
+
+func TestWriteAfterImportRefreshesHead(t *testing.T) {
+	s := newTestServer(t)
+	s.repoman = NewRepoMan(s)
+	s.evtman = newTestEvtman(t)
+	account := s.createTestAccount(t, "cached-import.pds.test")
+	s.seedGenesisRepo(t, account.Did, account.SigningKey)
+	mustApply(t, s, account.Did, Op{Type: OpTypeCreate, Collection: "app.bsky.feed.post", Rkey: strPtr("old"), Record: rmPostRecord("old")})
+	stale, err := s.getRepoActorByDid(context.Background(), account.Did)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, all, _ := importFixture(t, account.Did, []string{"app.bsky.feed.post/imported"})
+	if status, body := callImportRepo(t, s, account, bytes.NewReader(importCAR(t, []cid.Cid{root}, all))); status != 200 {
+		t.Fatalf("import: %d %s", status, body)
+	}
+	if _, err := s.repoman.applyWrites(context.Background(), stale.Repo, []Op{{Type: OpTypeCreate, Collection: "app.bsky.feed.post", Rkey: strPtr("new"), Record: rmPostRecord("new")}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	leaves := walkMstLeaves(t, s, account.Did)
+	if len(leaves) != 2 || !leaves["app.bsky.feed.post/imported"].Defined() || !leaves["app.bsky.feed.post/new"].Defined() {
+		t.Fatalf("write used pre-import tree: %v", leaves)
+	}
+	var records []models.Record
+	if err := s.db.Client().Where("did = ?", account.Did).Find(&records).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != len(leaves) {
+		t.Fatal("record index differs from tree")
+	}
+	for _, record := range records {
+		path := strings.Join([]string{record.Nsid, record.Rkey}, "/")
+		if leaves[path].String() != record.Cid || !blockstoreHas(t, s, account.Did, leaves[path]) {
+			t.Fatalf("record or block missing: %s", path)
+		}
 	}
 }

--- a/server/repo.go
+++ b/server/repo.go
@@ -335,8 +335,23 @@ func computeRemovedCids(prev *mst.Node, curr *mst.Node, prevCommitCids []cid.Cid
 	return out
 }
 
+// Serializes repository mutations within this server process.
+func (s *Server) lockRepoWrite(did string) func() {
+	value, _ := s.repoWriteLocks.LoadOrStore(did, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
+
 // TODO make use of swap commit
 func (rm *RepoMan) applyWrites(ctx context.Context, urepo models.Repo, writes []Op, swapCommit *string) ([]ApplyWriteResult, error) {
+	unlock := rm.s.lockRepoWrite(urepo.Did)
+	defer unlock()
+	current, err := rm.s.getRepoActorByDid(ctx, urepo.Did)
+	if err != nil {
+		return nil, err
+	}
+	urepo = current.Repo
 	rootcid, err := cid.Cast(urepo.Root)
 	if err != nil {
 		return nil, err

--- a/server/repo.go
+++ b/server/repo.go
@@ -145,7 +145,7 @@ type RepoCommit struct {
 	Rev string `json:"rev"`
 }
 
-func openRepo(ctx context.Context, bs blockstore.Blockstore, rootCid cid.Cid, did string) (*atp.Repo, error) {
+func openRepo(ctx context.Context, bs atp.RepoBlockSource, rootCid cid.Cid, did string) (*atp.Repo, error) {
 	commitBlock, err := bs.Get(ctx, rootCid)
 	if err != nil {
 		return nil, fmt.Errorf("reading commit block: %w", err)

--- a/server/server.go
+++ b/server/server.go
@@ -87,6 +87,8 @@ type Server struct {
 	scopeResolver scopes.PermissionSetResolver
 	fallbackProxy string
 
+	repoWriteLocks sync.Map // DID -> *sync.Mutex; shared by writes and imports.
+
 	// Optional client override for proxy and feed-record requests. Nil keeps
 	// each path's existing default client.
 	proxyHTTPClient *http.Client


### PR DESCRIPTION
The first migration-integrity change. Repo imports now validate the complete CAR before writing, then replace blocks, records, and the repo head in one transaction.

Malformed or incomplete imports are rejected. Database failures, cancellation, and a changed repo head roll back the import instead of leaving partial state. Cocoon’s existing re-signing behaviour stays unchanged.

Tests cover validation, rollback, replacement imports, and signatures. Blob references, migration status, and proxy headers are coming separately.