### PR TITLE
Wait for websocket handler cleanup before restoring test timeout

### DIFF
--- a/server/subscribe_repos_test.go
+++ b/server/subscribe_repos_test.go
@@ -351,8 +351,12 @@ func TestSubscribeReposWriteDeadlineUnwindsOnWedgedPeer(t *testing.T) {
 
 	s := newSubscribeTestServer(t)
 
+	handlerDone := make(chan struct{})
 	e := echo.New()
-	e.GET("/xrpc/com.atproto.sync.subscribeRepos", s.handleSyncSubscribeRepos)
+	e.GET("/xrpc/com.atproto.sync.subscribeRepos", func(c echo.Context) error {
+		defer close(handlerDone)
+		return s.handleSyncSubscribeRepos(c)
+	})
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -365,6 +369,8 @@ func TestSubscribeReposWriteDeadlineUnwindsOnWedgedPeer(t *testing.T) {
 	defer func() {
 		runtime.KeepAlive(nc)
 		_ = nc.Close()
+		// Include the handler's deferred close frame before restoring wsWriteTimeout.
+		<-handlerDone
 	}()
 
 	// Wait for the server to register the subscriber. The peer is not reading,


### PR DESCRIPTION
Small test-only fix for the race that showed up while checking the blob-reference changes.

The test was restoring `wsWriteTimeout` while the websocket handler could still be using it during teardown. It now waits for the handler to finish first.

The affected test passes 10 consecutive race-enabled runs, and the full race suite passes too.